### PR TITLE
[issue #5]std::vectorを使うようにする

### DIFF
--- a/BestSteal_Replica/AppCommon.h
+++ b/BestSteal_Replica/AppCommon.h
@@ -1,6 +1,7 @@
 ﻿#ifndef APP_COMMON_H_
 #define APP_COMMON_H_
 
+#include <vector>
 #include <windows.h>
 
 // new演算子をオーバーロードしているクラスはcrtdbg.hより前にincludeする必要有
@@ -34,6 +35,9 @@ template<typename T> struct Vertices {
 	T topLeft;
 	T bottomRight;
 };
+
+template<typename T>
+using DataTable = std::vector<std::vector<T>>;
 
 
 class AppCommon {

--- a/BestSteal_Replica/Character/CharacterCommon.cpp
+++ b/BestSteal_Replica/Character/CharacterCommon.cpp
@@ -4,13 +4,13 @@ namespace BestStealReplica {
 namespace Character {
 
 /* Static Public Functions -------------------------------------------------------------------------- */
-void CharacterCommon::SetTuTvs(Vertices<FloatPoint> chips[], int chipCntPerDir, int rowNum, int colNum) {
-	for (int i = 0; i < chipCntPerDir; ++i) {
-		chips[i] = GetTuTv(rowNum, colNum + i);
+void CharacterCommon::CreateChipTuTvs(int chipCount, int rowNum, int colNum, Vertices<FloatPoint> chips[]) {
+	for (int i = 0; i < chipCount; ++i) {
+		chips[i] = CreateTuTv(rowNum, colNum + i);
 	}
 }
 
-Vertices<FloatPoint> CharacterCommon::GetTuTv(int rowNum, int colNum) {
+Vertices<FloatPoint> CharacterCommon::CreateTuTv(int rowNum, int colNum) {
 	Vertices<FloatPoint> ret;
 	ret.topLeft.x = colNum / (float)CharacterCommon::CHIP_COUNT_PER_COL;
 	ret.topLeft.y = rowNum / (float)CharacterCommon::CHIP_COUNT_PER_ROW;
@@ -30,7 +30,7 @@ int CharacterCommon::GetAnimationNumber(int currentAnimationCnt) {
 	return currentAnimationCnt / AppCommon::FRAME_COUNT_PER_CUT;
 }
 
-Vertices<DrawingVertex> CharacterCommon::GetVertex(POINT topLeftXY, Vertices<POINT>(*getXY)(POINT), Vertices<FloatPoint> chip) {
+Vertices<DrawingVertex> CharacterCommon::CreateVertex(POINT topLeftXY, Vertices<POINT>(*getXY)(POINT), Vertices<FloatPoint> chip) {
 	Vertices<DrawingVertex> ret;
 	Vertices<POINT> xy = getXY(topLeftXY);
 

--- a/BestSteal_Replica/Character/CharacterCommon.h
+++ b/BestSteal_Replica/Character/CharacterCommon.h
@@ -14,11 +14,11 @@ public:
 	static const int WIDTH = 80;
 
 	/* Static Functions --------------------------------------------------------------------------------- */
-	static void SetTuTvs(Vertices<FloatPoint> chips[], int chipCount, int rowNum, int colNum);
-	static Vertices<FloatPoint> GetTuTv(int rowNum, int colNum);
+	static void CharacterCommon::CreateChipTuTvs(int chipCount, int rowNum, int colNum, Vertices<FloatPoint> chips[]);
+	static Vertices<FloatPoint> CreateTuTv(int rowNum, int colNum);
 	static void CountUpAnimationCnt(int* pAnimationCnt, int chipCntPerDir);
 	static int GetAnimationNumber(int currentAnimationCnt);
-	static Vertices<DrawingVertex> GetVertex(POINT topLeftXY, Vertices<POINT>(*getXY)(POINT), Vertices<FloatPoint> chip);
+	static Vertices<DrawingVertex> CreateVertex(POINT topLeftXY, Vertices<POINT>(*getXY)(POINT), Vertices<FloatPoint> chip);
 	static Vertices<POINT> GetChipXY(POINT topLeftXY);
 	static POINT CalcCenter(Vertices<POINT> xy);
 	static double CalcDistance(POINT xy1, POINT xy2);

--- a/BestSteal_Replica/Character/Enemy.h
+++ b/BestSteal_Replica/Character/Enemy.h
@@ -41,13 +41,11 @@ public:
 		EnemyInfo(int chipPosX, int chipPosY, AppCommon::Direction defaultDirection, AppCommon::KeyType holdingKey);
 	};
 
-	/* Constants ---------------------------------------------------------------------------------------- */
-	static const int MAX_ENEMY_COUNT = 7;
-
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Enemy(const POINT topLeftXY[Enemy::MAX_ENEMY_COUNT], EnemyInfo enemiesInfo[Enemy::MAX_ENEMY_COUNT], int enemyCount, int scoutableRadius, const Drawer& rDrawer);
+	Enemy(std::vector<EnemyInfo> enemiesInfo, std::vector<POINT> topLeftXYs, int scoutableRadius, const Drawer& rDrawer);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
+	int GetEnermyCount() const;
 	Vertices<POINT> GetEnemyXY(int enemyNum) const;
 	AppCommon::Direction GetHeadingDirection(int enemyNum) const;
 	Enemy::State GetState(int enemyNum) const;
@@ -89,13 +87,12 @@ private:
 	Vertices<FloatPoint> headingRightChips[Enemy::CHIP_COUNT_PER_DIRECTION];
 	Vertices<FloatPoint> exclamationMarkChip;
 
-	int enemyCount;
-	EnemyInfo enemiesInfo[MAX_ENEMY_COUNT];
+	std::vector<EnemyInfo> enemiesInfo;
 	const Drawer& rDrawer;
 	int scoutableRadius;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	Vertices<DrawingVertex> GetVertex(int enemyNum) const;
+	Vertices<DrawingVertex> CreateVertex(int enemyNum) const;
 	void TurnTo(POINT targetXY, int enemyNum);
 };
 

--- a/BestSteal_Replica/Character/Player.h
+++ b/BestSteal_Replica/Character/Player.h
@@ -73,7 +73,7 @@ private:
 	POINT topLeftXY;
 	POINT defaultTopLeftXY;
 	int currentKeepingStealingNum;
-	bool isDirectionChanged;
+	bool hasDirectionChanged;
 	bool isStealing;
 	AppCommon::Direction headingDirection;
 	int holdingGoldKeyCount;
@@ -90,10 +90,9 @@ private:
 	
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void SetDefaultProperty();
-	Vertices<DrawingVertex> GetVertex() const;
+	Vertices<DrawingVertex> CreateVertex() const;
 	Vertices<DrawingVertex> GetVerticesOnStealing(int afterImageNum) const;
-	int* GetHoldingKeyCnt(AppCommon::KeyType key);
-	int GetHoldingKeyCnt(AppCommon::KeyType key) const;
+	const int* GetHoldingKeyCnt(AppCommon::KeyType key) const;
 
 };
 

--- a/BestSteal_Replica/Main.cpp
+++ b/BestSteal_Replica/Main.cpp
@@ -18,8 +18,8 @@ static const TCHAR* TITLE = TEXT("Best Steal Replica");
 
 static IDirect3D9*			 pDirect3D;
 static D3DPRESENT_PARAMETERS d3dpp;
-static LPDIRECTINPUT8        g_lpDI;
-static LPDIRECTINPUTDEVICE8  g_lpDIDevice;
+static LPDIRECTINPUT8        lpDI;
+static LPDIRECTINPUTDEVICE8  lpDIDevice;
 
 static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp);
 static void WINAPI DI_Term();
@@ -83,28 +83,28 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
 	AppCommon::SetWindowWidth(rc.right - rc.left);
 
 	// DirectInputオブジェクト作成
-	HRESULT hr = DirectInput8Create(hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&g_lpDI, NULL);
+	HRESULT hr = DirectInput8Create(hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&lpDI, NULL);
 	if FAILED(hr) {
 		// DirectInput not available; take appropriate action 
 		return false;
 	}
 
 	// DirectInputキーボードデバイスの作成
-	hr = g_lpDI->CreateDevice(GUID_SysKeyboard, &g_lpDIDevice, NULL);
+	hr = lpDI->CreateDevice(GUID_SysKeyboard, &lpDIDevice, NULL);
 	if FAILED(hr) {
 		DI_Term();
 		return FALSE;
 	}
 
 	// キーボードデータフォーマットの設定
-	hr = g_lpDIDevice->SetDataFormat(&c_dfDIKeyboard);
+	hr = lpDIDevice->SetDataFormat(&c_dfDIKeyboard);
 	if FAILED(hr) {
 		DI_Term();
 		return FALSE;
 	}
 
 	// キーボードの動作の設定 
-	hr = g_lpDIDevice->SetCooperativeLevel(hWnd, DISCL_FOREGROUND | DISCL_NONEXCLUSIVE);
+	hr = lpDIDevice->SetCooperativeLevel(hWnd, DISCL_FOREGROUND | DISCL_NONEXCLUSIVE);
 	if FAILED(hr) {
 		DI_Term();
 		return FALSE;
@@ -128,10 +128,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
 		} else {
 			SyncNow = timeGetTime();
 			if (SyncNow - SyncOld >= 1000 / 60) {
-				if (g_lpDIDevice) {
-					g_lpDIDevice->Acquire();
+				if (lpDIDevice) {
+					lpDIDevice->Acquire();
 				}
-				sceneController.Control(g_lpDIDevice);
+				sceneController.Control(lpDIDevice);
 				SyncOld = SyncNow;
 			}
 		}
@@ -165,15 +165,15 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp) {
 }
 
 static void WINAPI DI_Term(void) {
-	if (g_lpDI) {
-		if (g_lpDIDevice) {
+	if (lpDI) {
+		if (lpDIDevice) {
 			// Always unacquire device before calling Release(). 
-			g_lpDIDevice->Unacquire();
-			g_lpDIDevice->Release();
-			g_lpDIDevice = NULL;
+			lpDIDevice->Unacquire();
+			lpDIDevice->Release();
+			lpDIDevice = NULL;
 		}
-		g_lpDI->Release();
-		g_lpDI = NULL;
+		lpDI->Release();
+		lpDI = NULL;
 	}
 }
 

--- a/BestSteal_Replica/Map/Map.h
+++ b/BestSteal_Replica/Map/Map.h
@@ -23,7 +23,7 @@ class Stone;
 class Map {
 public:
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Map(int yChipCount, int xChipCount, Drawer* pDrawer);
+	Map(Drawer* pDrawer);
 	~Map();
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
@@ -51,18 +51,13 @@ public:
 
 private:
 	/* Constants ---------------------------------------------------------------------------------------- */
-	static const int MAX_Y_CHIP_COUNT = 21;
-	static const int MAX_X_CHIP_COUNT = 30;
-
 	static const TCHAR* FILE_PATH;
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	int yChipCount;
-	int xChipCount;
 	Drawer* pDrawer;
 	POINT defaultTopLeft;
 	POINT topLeft;
-	MapChip* pMapData[MAX_Y_CHIP_COUNT][MAX_X_CHIP_COUNT];
+	DataTable<MapChip*> pMapData;
 	std::vector<MapChipDoor*> pDoorMapChips;
 	MapChipJewelry* pJewelryMapChip;
 	std::vector<Stone*> pStones;

--- a/BestSteal_Replica/Map/MapChip.cpp
+++ b/BestSteal_Replica/Map/MapChip.cpp
@@ -76,7 +76,7 @@ void MapChip::SetXY(POINT topLeftXY) {
 	this->vertices.bottomRight.y = xy.bottomRight.y;
 }
 
-Vertices<DrawingVertex> MapChip::GetVertex() const {
+Vertices<DrawingVertex> MapChip::CreateVertex() const {
 	return this->vertices;
 }
 

--- a/BestSteal_Replica/Map/MapChip.h
+++ b/BestSteal_Replica/Map/MapChip.h
@@ -28,7 +28,7 @@ public:
 	virtual void SetChipNumber();
 	POINT GetTopLeftXY() const;
 	void SetXY(POINT topLeftXY);
-	Vertices<DrawingVertex> GetVertex() const;
+	Vertices<DrawingVertex> CreateVertex() const;
 
 protected:
 	/* Structs ------------------------------------------------------------------------------------------ */

--- a/BestSteal_Replica/Map/Stone.cpp
+++ b/BestSteal_Replica/Map/Stone.cpp
@@ -117,7 +117,7 @@ void Stone::KeepBeingThrown() {
 }
 
 void Stone::Draw() const {
-	Vertices<DrawingVertex> vertex = GetVertex();
+	Vertices<DrawingVertex> vertex = CreateVertex();
 	switch (this->state) {
 		case Stone::State::BEING_THROWN:
 		case Stone::State::DROPPED:
@@ -177,7 +177,7 @@ void Stone::BackOnePixcel() {
 
 
 /* Private Functions  ------------------------------------------------------------------------------- */
-Vertices<DrawingVertex> Stone::GetVertex() const {
+Vertices<DrawingVertex> Stone::CreateVertex() const {
 	Vertices<DrawingVertex> ret;
 
 	DrawingVertex* pVerticesArr[] = { &ret.topLeft, &ret.bottomRight };

--- a/BestSteal_Replica/Map/Stone.h
+++ b/BestSteal_Replica/Map/Stone.h
@@ -62,7 +62,7 @@ private:
 	POINT topLeftXYOnGnd;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	Vertices<DrawingVertex> GetVertex() const;
+	Vertices<DrawingVertex> CreateVertex() const;
 
 };
 

--- a/BestSteal_Replica/SceneController.cpp
+++ b/BestSteal_Replica/SceneController.cpp
@@ -56,7 +56,7 @@ void SceneController::Control(LPDIRECTINPUTDEVICE8 pDIDevice) {
 
 
 /* Private Functions  ------------------------------------------------------------------------------- */
-AppCommon::Key SceneController::ProcessKBInput(LPDIRECTINPUTDEVICE8 pDIDevice) const{
+AppCommon::Key SceneController::ProcessKBInput(LPDIRECTINPUTDEVICE8 pDIDevice) const {
 	#define KEYDOWN(name, key) (name[key] & 0x80) > 0
 
 	AppCommon::Key ret;

--- a/BestSteal_Replica/Stage/IStage.h
+++ b/BestSteal_Replica/Stage/IStage.h
@@ -1,6 +1,7 @@
 ﻿#ifndef ISTAGE_H_
 #define ISTAGE_H_
 
+#include <vector>
 #include <windows.h>
 
 #include "MapCommon.h"
@@ -17,9 +18,7 @@ public:
 	virtual int GetXChipCount() const = 0;
 	virtual Map::MapCommon::MapChipType GetMapChipType(int y, int x) const = 0;
 	virtual POINT GetPlayerFirstChipPos() const = 0;
-	virtual int GetEnemyCount() const = 0;
-	virtual POINT GetEnemyChipPos(int enemyNum) const = 0;
-	virtual Character::Enemy::EnemyInfo* GetEnemiesInfo() const = 0;
+	virtual std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const = 0;
 	virtual int GetEnemyScoutableRadius() const = 0;
 	virtual int GetMaxStoneCount() const = 0;
 };

--- a/BestSteal_Replica/Stage/Stage1.cpp
+++ b/BestSteal_Replica/Stage/Stage1.cpp
@@ -1,4 +1,5 @@
 ﻿#include "Stage1.h"
+#include "AppCommon.h"
 #include "Enemy.h"
 
 
@@ -10,7 +11,7 @@ using Map::MapCommon;
 using Character::CharacterCommon;
 using Character::Enemy;
 
-MapCommon::MapChipType mapChipTypes[Stage1::Y_CHIP_COUNT][Stage1::X_CHIP_COUNT] = {
+DataTable<MapCommon::MapChipType> mapChipTypes = {
 	// 1									2									3									4									5									6									7									8									9									10									11									12									13									14									15									16									17									18									19									20									21									22									23									24									25									26									27									28									29									30
 	{ MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD },		// 1
 	{ MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL_SIDE, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD },		// 2
@@ -35,7 +36,7 @@ MapCommon::MapChipType mapChipTypes[Stage1::Y_CHIP_COUNT][Stage1::X_CHIP_COUNT] 
 	{ MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::WALL_SIDE, MapCommon::MapChipType::WALL_SIDE, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD, MapCommon::MapChipType::ROAD },		// 21
 };
 
-Enemy::EnemyInfo enemiesInfo[Stage1::ENEMY_COUNT] = {
+std::vector<Enemy::EnemyInfo> enemiesInfo = {
 	Enemy::EnemyInfo(6, 4, AppCommon::Direction::RIGHT, AppCommon::KeyType::None),
 	Enemy::EnemyInfo(24, 0, AppCommon::Direction::LEFT, AppCommon::KeyType::Silver),
 	Enemy::EnemyInfo(1, 20, AppCommon::Direction::RIGHT, AppCommon::KeyType::Silver),
@@ -49,11 +50,11 @@ Enemy::EnemyInfo enemiesInfo[Stage1::ENEMY_COUNT] = {
 
 /* Getters / Setters -------------------------------------------------------------------------------- */
 int Stage1::GetYChipCount() const {
-	return Stage1::Y_CHIP_COUNT;
+	return mapChipTypes.size();
 }
 
 int Stage1::GetXChipCount() const {
-	return Stage1::X_CHIP_COUNT;
+	return mapChipTypes[0].size();
 }
 
 MapCommon::MapChipType Stage1::GetMapChipType(int y, int x) const {
@@ -67,15 +68,7 @@ POINT Stage1::GetPlayerFirstChipPos() const {
 	return ret;
 }
 
-int Stage1::GetEnemyCount() const {
-	return Stage1::ENEMY_COUNT;
-}
-
-POINT Stage1::GetEnemyChipPos(int enemyNum) const {
-	return enemiesInfo[enemyNum].chipPos;
-}
-
-Enemy::EnemyInfo* Stage1::GetEnemiesInfo() const {
+std::vector<Enemy::EnemyInfo> Stage1::GetEnemiesInfo() const {
 	return enemiesInfo;
 }
 

--- a/BestSteal_Replica/Stage/Stage1.h
+++ b/BestSteal_Replica/Stage/Stage1.h
@@ -9,22 +9,18 @@ namespace Stage {
 class Stage1 : public IStage {
 
 public:
-	/* Constants ---------------------------------------------------------------------------------------- */
-	static const int Y_CHIP_COUNT = 21;
-	static const int X_CHIP_COUNT = 30;
-	static const int ENEMY_COUNT = 7;
-	static const int MAX_STONE_COUNT = 3;
-
 	/* Getters / Setters -------------------------------------------------------------------------------- */
 	int GetYChipCount() const;
 	int GetXChipCount() const;
 	Map::MapCommon::MapChipType GetMapChipType(int y, int x) const;
 	POINT GetPlayerFirstChipPos() const;
-	int GetEnemyCount() const;
-	POINT GetEnemyChipPos(int enemyNum) const;
-	Character::Enemy::EnemyInfo* GetEnemiesInfo() const;
+	std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const;
 	int GetEnemyScoutableRadius() const;
 	int GetMaxStoneCount() const;
+
+private:
+	/* Constants ---------------------------------------------------------------------------------------- */
+	static const int MAX_STONE_COUNT = 3;
 };
 
 }

--- a/BestSteal_Replica/StageController.cpp
+++ b/BestSteal_Replica/StageController.cpp
@@ -1,7 +1,6 @@
 ﻿#include <vector>
 
 #include "StageController.h"
-
 #include "Stage1.h"
 #include "Drawer.h"
 #include "Map.h"
@@ -34,7 +33,7 @@ StageController::~StageController() {
 void StageController::LoadStage(const Stage::IStage& rStage) {
 	// マップ情報
 	this->pStage = &rStage;
-	this->pMap = new Map::Map(this->pStage->GetYChipCount(), this->pStage->GetXChipCount(), this->pDrawer);
+	this->pMap = new Map::Map(this->pDrawer);
 	this->pMap->Load(*this->pStage);
 
 	// プレイヤー情報
@@ -42,12 +41,12 @@ void StageController::LoadStage(const Stage::IStage& rStage) {
 	this->pPlayer = new Player(this->pMap->GetTopLeftXYonChip(playerChipPos), this->pDrawer);
 
 	// 敵情報
-	int enemyCount = this->pStage->GetEnemyCount();
-	POINT enemiesXY[Enemy::MAX_ENEMY_COUNT];
-	for (int i = 0; i < enemyCount; ++i) {
-		enemiesXY[i] = this->pMap->GetTopLeftXYonChip(this->pStage->GetEnemyChipPos(i));
+	std::vector<Enemy::EnemyInfo> enemiesInfo = this->pStage->GetEnemiesInfo();
+	std::vector<POINT> enemiesXY;
+	for (int i = 0; i < (int)enemiesInfo.size(); ++i) {
+		enemiesXY.push_back(this->pMap->GetTopLeftXYonChip(enemiesInfo[i].chipPos));
 	}
-	this->pEnemy = new Enemy(enemiesXY, this->pStage->GetEnemiesInfo(), this->pStage->GetEnemyCount(), this->pStage->GetEnemyScoutableRadius(), *this->pDrawer);
+	this->pEnemy = new Enemy(enemiesInfo, enemiesXY, this->pStage->GetEnemyScoutableRadius(), *this->pDrawer);
 }
 
 void StageController::Control(AppCommon::Key key) {
@@ -263,7 +262,7 @@ void StageController::ControlEnemy(int playerMovingPixel, const Handling& rHandl
 	this->pEnemy->ScoutPlayer(playerXY, rHandling.isWalking);
 
 	// 突進可能か
-	for (int i = 0; i < this->pStage->GetEnemyCount(); ++i) {
+	for (int i = 0; i < this->pEnemy->GetEnermyCount(); ++i) {
 		if (this->pEnemy->GetState(i) == Enemy::State::GOT_STOLEN) {
 			continue;
 		}


### PR DESCRIPTION
- 配列を使用していた箇所でstd::vectorに置き換えられる場所は置き換え
- 上記により配列数を保持する定数を削除
- std::vectorで2次元配列を構成するtypedef(using)作成
- ついでにちょこっとリファクタリング（気付いた部分のみ）
    - 関数のout引数は引数リストの最後にする
    - ヘッダに定義していない変数はプレフィックス"g_"は付けない
    - getter以外ではGetHoge()形式はできるだけ使用しない
    - `Player::GetHoldingKeyCnt()`をconstと非constでオーバーライドしていたが、処理がほぼ同じなので1つにできるようにした