### PR TITLE
[issue #6]Drawerクラスの利用方法変更

### DIFF
--- a/BestSteal_Replica/Drawing/Drawer.cpp
+++ b/BestSteal_Replica/Drawing/Drawer.cpp
@@ -22,7 +22,7 @@ struct CUSTOMVERTEX {
 
 /* Static Variables --------------------------------------------------------------------------------- */
 IDirect3DDevice9* pD3Device = nullptr;
-std::vector<IDrawable*> pDrawables;
+std::vector<const IDrawable*> pDrawables;
 std::map<Drawing::TextureType, LPDIRECT3DTEXTURE9> textures;
 }
 
@@ -55,10 +55,10 @@ UINT16 Drawer::GetAlphaOnBlinking(int time) {
 	return (UINT16)alpha;
 }
 
-bool Drawer::AddDrawable(IDrawable* pDrawable) {
+bool Drawer::AddDrawable(const IDrawable& rDrawable) {
 	bool ret = true;
-	pDrawables.push_back(pDrawable);
-	std::vector<Drawing::TextureType> requiredTextureTypes = pDrawable->GetTextureTypes();
+	pDrawables.push_back(&rDrawable);
+	std::vector<Drawing::TextureType> requiredTextureTypes = rDrawable.GetTextureTypes();
 	for (auto tex : requiredTextureTypes) {
 		// ロードされていないテクスチャのみ処理
 		if (textures.count(tex) == 0) {

--- a/BestSteal_Replica/Drawing/Drawer.h
+++ b/BestSteal_Replica/Drawing/Drawer.h
@@ -21,7 +21,7 @@ public:
 	static void Create(HWND hWnd, IDirect3D9* pDirect3D, D3DPRESENT_PARAMETERS* pD3dpp);
 	static void Release();
 	static UINT16 GetAlphaOnBlinking(int time);
-	static bool AddDrawable(IDrawable* pDrawable);
+	static bool AddDrawable(const IDrawable& rDrawable);
 	static void Draw();
 	static void Blackout();
 

--- a/BestSteal_Replica/StageController.cpp
+++ b/BestSteal_Replica/StageController.cpp
@@ -27,13 +27,13 @@ void StageController::LoadStage(const Stage::IStage& rStage) {
 	// マップ情報
 	this->pStage = &rStage;
 	this->pMap = new Map::Map();
-	Drawing::Drawer::AddDrawable(this->pMap);
+	Drawing::Drawer::AddDrawable(*this->pMap);
 	this->pMap->Load(*this->pStage);
 
 	// プレイヤー情報
 	POINT playerChipPos = this->pStage->GetPlayerFirstChipPos();
 	this->pPlayer = new Player(this->pMap->GetTopLeftXYonChip(playerChipPos));
-	Drawing::Drawer::AddDrawable(this->pPlayer);
+	Drawing::Drawer::AddDrawable(*this->pPlayer);
 
 	// 敵情報
 	std::vector<Enemy::EnemyInfo> enemiesInfo = this->pStage->GetEnemiesInfo();
@@ -42,7 +42,7 @@ void StageController::LoadStage(const Stage::IStage& rStage) {
 		enemiesXY.push_back(this->pMap->GetTopLeftXYonChip(enemiesInfo[i].chipPos));
 	}
 	this->pEnemy = new Enemy(enemiesInfo, enemiesXY, this->pStage->GetEnemyScoutableRadius());
-	Drawing::Drawer::AddDrawable(this->pEnemy);
+	Drawing::Drawer::AddDrawable(*this->pEnemy);
 }
 
 void StageController::Control(AppCommon::Key key) {


### PR DESCRIPTION
- vectorに格納する`IDrawable`の型をconstポインタに変更  
（参照型はvectorに格納できないのでconstポインタにした）