### PR TITLE
[issue #11]関数呼び出し時の値渡しを参照渡しに変更する

### DIFF
--- a/BestSteal_Replica/AppCommon.cpp
+++ b/BestSteal_Replica/AppCommon.cpp
@@ -9,8 +9,6 @@ static AppCommon::SceneType scene;
 }
 
 /* Constructor / Destructor ------------------------------------------------------------------------- */
-FloatPoint::FloatPoint() {}
-
 FloatPoint::FloatPoint(float x, float y) : x(x), y(y) {}
 
 

--- a/BestSteal_Replica/AppCommon.h
+++ b/BestSteal_Replica/AppCommon.h
@@ -20,7 +20,7 @@ struct FloatPoint {
 	float x;
 	float y;
 
-	FloatPoint();
+	FloatPoint() = default;
 	FloatPoint(float x, float y);
 };
 

--- a/BestSteal_Replica/Character/CharacterCommon.h
+++ b/BestSteal_Replica/Character/CharacterCommon.h
@@ -15,14 +15,16 @@ public:
 	static const int WIDTH = 80;
 
 	/* Static Functions --------------------------------------------------------------------------------- */
-	static void CharacterCommon::CreateChipTuTvs(int chipCount, int rowIdx, int colIdx, Vertices<FloatPoint> chips[]);
-	static Vertices<FloatPoint> CreateTuTv(int rowIdx, int colIdx);
+	static void CreateChipTuTvs(int chipCount, int rowIdx, int colIdx, Vertices<FloatPoint> pRetArr[]);
+	static void CreateTuTv(int rowIdx, int colIdx, Vertices<FloatPoint>* pRet);
 	static void CountUpAnimationCnt(int* pAnimationCnt, int chipCntPerDir);
 	static int GetAnimationNumber(int currentAnimationCnt);
-	static Vertices<Drawing::DrawingVertex> CreateVertex(POINT topLeftXY, Vertices<POINT>(*getXY)(POINT), Vertices<FloatPoint> chip);
-	static Vertices<POINT> GetChipXY(POINT topLeftXY);
-	static POINT CalcCenter(Vertices<POINT> xy);
-	static double CalcDistance(POINT xy1, POINT xy2);
+	static void CreateDrawingVertices(const POINT& rTopLeftXY, void(*convertTopLeftToVertices)(const POINT&, Vertices<POINT>*), const Vertices<FloatPoint>& rChip, Vertices<Drawing::DrawingVertex>* pRet);
+	static void ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet);
+	static void CalcCharacterXY(const POINT& rTopLeftXY, int width, int height, Vertices<POINT>* pRet);
+	static void CalcCenter(const Vertices<POINT>& rXY, POINT* pRet);
+	static double CalcDistance(const POINT& rXY1, const POINT& rXY2);
+	static bool IsOverlapping(const Vertices<POINT>& rXY1, const Vertices<POINT>& rXY2);
 
 private:
 	/* Constants ---------------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/Character/Enemy.h
+++ b/BestSteal_Replica/Character/Enemy.h
@@ -39,7 +39,7 @@ public:
 		int restTimeForCancelFinding;
 		int restTimeForBackingToNormal;
 
-		EnemyInfo();
+		EnemyInfo() = default;
 		EnemyInfo(int chipPosX, int chipPosY, AppCommon::Direction defaultDirection, AppCommon::GateKeyType holdingGateKey);
 	};
 
@@ -49,24 +49,24 @@ public:
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	std::vector<Drawing::TextureType> GetTextureTypes() const;
-
 	int GetEnermyCount() const;
-	Vertices<POINT> GetEnemyXY(int enemyIdx) const;
 	AppCommon::Direction GetHeadingDirection(int enemyIdx) const;
 	Enemy::State GetState(int enemyIdx) const;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pDrawingContexts) const;
+	void ConfigureTextureTypes(std::vector<Drawing::TextureType>* pRet) const;
+	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const;
 
 	void Stay();
-	void Move(POINT xy);
+	void Move(const POINT& rXY);
+	void CalcEnemyXY(int enemyIdx, Vertices<POINT>* pRet) const;
+	void CalcCenterXY(int enemyIdx, POINT* pRet) const;
 	void ScoutStone(const std::vector<Vertices<POINT>>& rStonesXY);
-	void ScoutPlayer(Vertices<POINT> playerXY, bool isPlayerWalking);
-	AppCommon::GateKeyType GetStolen(Vertices<POINT> playerXY, bool isPlayerStealing);
+	void ScoutPlayer(const POINT& rPlayerCenter, bool isPlayerWalking);
+	AppCommon::GateKeyType GetStolen(const Vertices<POINT>& rPlayerXY, bool isPlayerStealing);
 	void Attack(int enemyIdx, bool canSeePlayer);
-	bool CanKillPlayer(Vertices<POINT> playerXY) const;
+	bool CanKillPlayer(const Vertices<POINT>& rPlayerXY) const;
 	void BackToDefaultPosition();
 
 
@@ -102,8 +102,9 @@ private:
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	Vertices<Drawing::DrawingVertex> CreateVertex(int enemyIdx) const;
-	void TurnTo(POINT targetXY, int enemyIdx);
+	void CreateDrawingVertices(int enemyIdx, Vertices<Drawing::DrawingVertex>* pRet) const;
+	void TurnTo(const POINT& rTargetXY, int enemyIdx);
+
 };
 
 }

--- a/BestSteal_Replica/Character/Player.h
+++ b/BestSteal_Replica/Character/Player.h
@@ -23,26 +23,26 @@ public:
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	std::vector<Drawing::TextureType> GetTextureTypes() const;
-
 	bool IsStealing() const;
 	AppCommon::Direction GetHeadingDirection() const;
+	void SetDirection(AppCommon::Direction direction);
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pDrawingContexts) const;
+	void ConfigureTextureTypes(std::vector<Drawing::TextureType>* pRet) const;
+	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const;
 
-	void SetDirection(AppCommon::Direction direction);
-	void Walk(POINT movingPoint);
+	void Walk(const POINT& rMovingPoint);
 	void Stay();
 	void StartStealing();
 	void KeepStealing();
-	void Move(POINT xy);
+	void Move(const POINT& rXY);
 	bool IsStayingNearlyWindowTop() const;
 	bool IsStayingNearlyWindowRight() const;
 	bool IsStayingNearlyWindowBottom() const;
 	bool IsStayingNearlyWindowLeft() const;
-	Vertices<POINT> GetPlayerXY() const;
+	void CalcPlayerXY(Vertices<POINT>* pRet) const;
+	void CalcCenterXY(POINT* pRet) const;
 	bool HasGateKey(AppCommon::GateKeyType key) const;
 	void GainGateKey(AppCommon::GateKeyType key);
 	void LoseGateKey(AppCommon::GateKeyType key);
@@ -98,9 +98,9 @@ private:
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void SetDefaultProperty();
-	Vertices<Drawing::DrawingVertex> CreateVertex() const;
-	Vertices<Drawing::DrawingVertex> GetVerticesOnStealing(int afterImageNum) const;
+	void ReturnPropertiesToDefault();
+	void CreateVertices(Vertices<Drawing::DrawingVertex>* pVertices) const;
+	void CalcVerticesOnStealing(int afterImageNum, Vertices<Drawing::DrawingVertex>* pVertices) const;
 	const int* GetHoldingGateKeyCnt(AppCommon::GateKeyType key) const;
 
 };

--- a/BestSteal_Replica/Drawing/Drawer.cpp
+++ b/BestSteal_Replica/Drawing/Drawer.cpp
@@ -20,16 +20,15 @@ struct CUSTOMVERTEX {
 	float           tu, tv;                 //テクスチャ座標
 };
 
+/* Constants ---------------------------------------------------------------------------------------- */
+const TCHAR* MAP_CHIP_FILE_PATH = TEXT("image\\mapchip.png");
+const TCHAR* CHARACTER_FILE_PATH = TEXT("image\\character.png");
+
 /* Static Variables --------------------------------------------------------------------------------- */
 IDirect3DDevice9* pD3Device = nullptr;
 std::vector<const IDrawable*> pDrawables;
 std::map<Drawing::TextureType, LPDIRECT3DTEXTURE9> textures;
 }
-
-
-/* Constants ---------------------------------------------------------------------------------------- */
-const TCHAR* Drawer::MAP_CHIP_FILE_PATH = TEXT("image\\mapchip.png");
-const TCHAR* Drawer::CHARACTER_FILE_PATH = TEXT("image\\character.png");
 
 
 /* Static Public Functions -------------------------------------------------------------------------- */
@@ -59,7 +58,10 @@ UINT16 Drawer::GetAlphaOnBlinking(int time) {
 bool Drawer::AddDrawable(const IDrawable& rDrawable) {
 	bool ret = true;
 	pDrawables.push_back(&rDrawable);
-	std::vector<Drawing::TextureType> requiredTextureTypes = rDrawable.GetTextureTypes();
+
+	// テクスチャ設定
+	std::vector<Drawing::TextureType> requiredTextureTypes;
+	rDrawable.ConfigureTextureTypes(&requiredTextureTypes);
 	for (auto& tex : requiredTextureTypes) {
 		// ロードされていないテクスチャのみ処理
 		if (textures.count(tex) == 0) {
@@ -158,9 +160,8 @@ void Drawer::BeginDraw() {
 }
 
 void Drawer::Draw(const DrawingContext& rContext) {
-	if ((rContext.vertices.topLeft.x < 0 && rContext.vertices.topLeft.y < 0 && rContext.vertices.bottomRight.x < 0 && rContext.vertices.bottomRight.y < 0)
-		|| (rContext.vertices.topLeft.x > AppCommon::GetWindowWidth() && rContext.vertices.topLeft.y > AppCommon::GetWindowHeight()
-		&& rContext.vertices.bottomRight.x > AppCommon::GetWindowWidth() && rContext.vertices.bottomRight.y > AppCommon::GetWindowHeight())) {
+	if (rContext.vertices.bottomRight.x < 0 || rContext.vertices.bottomRight.y < 0
+		|| rContext.vertices.topLeft.x > AppCommon::GetWindowWidth() || rContext.vertices.topLeft.y > AppCommon::GetWindowHeight()) {
 		// 描画範囲外
 		return;
 	}

--- a/BestSteal_Replica/Drawing/Drawer.h
+++ b/BestSteal_Replica/Drawing/Drawer.h
@@ -26,10 +26,6 @@ public:
 	static void Blackout();
 
 private:
-	/* Constants ---------------------------------------------------------------------------------------- */
-	static const TCHAR* Drawer::MAP_CHIP_FILE_PATH;
-	static const TCHAR* Drawer::CHARACTER_FILE_PATH;
-
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
 	Drawer();
 

--- a/BestSteal_Replica/Drawing/IDrawable.h
+++ b/BestSteal_Replica/Drawing/IDrawable.h
@@ -12,11 +12,9 @@ namespace Drawing {
 
 class IDrawable {
 public:
-	/* Getters / Setters -------------------------------------------------------------------------------- */
-	virtual std::vector<TextureType> GetTextureTypes() const = 0;
-
 	/* Functions ---------------------------------------------------------------------------------------- */
-	virtual void CreateDrawingContexts(std::vector<DrawingContext>* pDrawingContexts) const = 0;
+	virtual void ConfigureTextureTypes(std::vector<Drawing::TextureType>* pRet) const = 0;
+	virtual void CreateDrawingContexts(std::vector<DrawingContext>* pRet) const = 0;
 };
 
 }

--- a/BestSteal_Replica/Map/Map.h
+++ b/BestSteal_Replica/Map/Map.h
@@ -30,31 +30,30 @@ public:
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	std::vector<Drawing::TextureType> GetTextureTypes() const;
-
-	POINT GetTopLeftXYonChip(POINT mapChipPos) const;
-	MapChipType GetMapChipType(POINT mapChipPos) const;
+	MapChipType GetMapChipType(const POINT& rMapChipPos) const;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pDrawingContexts) const;
+	void ConfigureTextureTypes(std::vector<Drawing::TextureType>* pRet) const;
+	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const;
 
 	void Load(const Stage::IStage& rStage);
-	void Move(POINT xy);
+	void Move(const POINT& rXY);
 	void MoveToDefault();
-	bool IsOnRoad(Vertices<POINT> xy) const;
 	bool IsMovableX(int x) const;
 	bool IsMovableY(int y) const;
+	bool IsOnRoad(const Vertices<POINT>& rXY) const;
+	void ConvertMapChipPosToTopLeftXY(const POINT& rMapChipPos, POINT* pRet) const;
 	void KeepOpeningGates();
-	POINT GetFrontMapChipPos(Vertices<POINT> playerXY, AppCommon::Direction headingDirection) const;
-	bool StartOpeningGate(POINT mapChipPos);
-	bool IsGateOpened(POINT mapChipPos) const;
-	bool ExistsWallBetween(POINT xy1, POINT xy2) const;
+	void ConvertToCharacterFrontMapChipPos(const Vertices<POINT>& rPlayerXY, AppCommon::Direction headingDirection, POINT* pRet) const;
+	bool StartOpeningGate(const POINT& rMapChipPos);
+	bool IsGateOpened(const POINT& rMapChipPos) const;
+	bool ExistsWallBetween(const POINT& rXY1, const POINT& rXY2) const;
 	void OpenJewelryBox();
-	POINT ConvertToMapChipPos(POINT xy) const;
-	void AddStone(POINT topLeftXY, AppCommon::Direction direction);
+	void ConvertToMapChipPos(const POINT& rXY, POINT* pRet) const;
+	void AddStone(const POINT& rTopLeftXY, AppCommon::Direction direction);
 	void AnimateStones();
-	std::vector<Vertices<POINT>> GetDroppedStoneXYs() const;
+	void CalcDroppedStoneXYs(std::vector<Vertices<POINT>>* pRet) const;
 
 
 private:
@@ -73,10 +72,9 @@ private:
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void AssignChipNumber();
-	void SetChipXY();
-	bool IsOnRoad(POINT mapChipPos) const;
-	bool Map::IsMovable(int targetPoint, int topLeftPoint, int mapChipCount, int mapChipSize, int windowSize) const;
-
+	void ConfigureChipXY();
+	bool IsOnRoad(const POINT& rMapChipPos) const;
+	bool IsMovable(int targetPoint, int topLeftPoint, int mapChipCount, int mapChipSize, int windowSize) const;
 };
 
 }

--- a/BestSteal_Replica/Map/MapChip.cpp
+++ b/BestSteal_Replica/Map/MapChip.cpp
@@ -25,27 +25,21 @@ MapChip* MapChip::Create(MapChipType chipType) {
 	}
 }
 
-Vertices<FloatPoint> MapChip::GetTuTvs(int mapChipNumber) {
-	Vertices<FloatPoint> ret;
-
+void MapChip::ConvertChipNumberToTuTv(int mapChipNumber, Vertices<FloatPoint>* pRet) {
 	int chipPosX = mapChipNumber % CHIP_COUNT_PER_ROW;
 	int chipPosY = mapChipNumber / CHIP_COUNT_PER_ROW;
 
-	ret.topLeft.x = (float)chipPosX / (float)CHIP_COUNT_PER_ROW;
-	ret.topLeft.y = (float)chipPosY / (float)CHIP_COUNT_PER_COL;
-	ret.bottomRight.x = (float)(chipPosX + 1) / (float)CHIP_COUNT_PER_ROW;
-	ret.bottomRight.y = (float)(chipPosY + 1) / (float)CHIP_COUNT_PER_COL;
-
-	return ret;
+	pRet->topLeft.x = (float)chipPosX / (float)CHIP_COUNT_PER_ROW;
+	pRet->topLeft.y = (float)chipPosY / (float)CHIP_COUNT_PER_COL;
+	pRet->bottomRight.x = (float)(chipPosX + 1) / (float)CHIP_COUNT_PER_ROW;
+	pRet->bottomRight.y = (float)(chipPosY + 1) / (float)CHIP_COUNT_PER_COL;
 }
 
-Vertices<POINT> MapChip::GetXY(POINT topLeftXY) {
-	Vertices<POINT> ret;
-	ret.topLeft.x = topLeftXY.x;
-	ret.topLeft.y = topLeftXY.y;
-	ret.bottomRight.x = topLeftXY.x + MapChip::WIDTH;
-	ret.bottomRight.y = topLeftXY.y + MapChip::HEIGHT;
-	return ret;
+void MapChip::ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet) {
+	pRet->topLeft.x = rTopLeftXY.x;
+	pRet->topLeft.y = rTopLeftXY.y;
+	pRet->bottomRight.x = rTopLeftXY.x + MapChip::WIDTH;
+	pRet->bottomRight.y = rTopLeftXY.y + MapChip::HEIGHT;
 }
 
 
@@ -54,30 +48,37 @@ MapChipType MapChip::GetChipType() const {
 	return this->chipType;
 }
 
+void MapChip::GetTopLeftXY(POINT* pRet) const {
+	pRet->x = this->vertices.topLeft.x;
+	pRet->y = this->vertices.topLeft.y;
+}
+
+void MapChip::SetXY(const POINT& rTopLeftXY) {
+	this->vertices.topLeft.x = rTopLeftXY.x;
+	this->vertices.topLeft.y = rTopLeftXY.y;
+	this->vertices.bottomRight.x = rTopLeftXY.x + MapChip::WIDTH;
+	this->vertices.bottomRight.y = rTopLeftXY.y + MapChip::HEIGHT;
+}
+
+
+/* Public Functions --------------------------------------------------------------------------------- */
 void MapChip::AssignChipNumber() {
 	this->chipNumber = (int)this->chipType;
 
 	// テクスチャー上のマップチップの位置
-	SetTuTv();
+	ConfigureTuTv();
 }
 
-POINT MapChip::GetTopLeftXY() const {
-	POINT ret;
-	ret.x = this->vertices.topLeft.x;
-	ret.y = this->vertices.topLeft.y;
-	return ret;
-}
+void MapChip::CreateDrawingVertices(Vertices<Drawing::DrawingVertex>* pRet) const {
+	pRet->topLeft.x = this->vertices.topLeft.x;
+	pRet->topLeft.y = this->vertices.topLeft.y;
+	pRet->topLeft.tu = this->vertices.topLeft.tu;
+	pRet->topLeft.tv = this->vertices.topLeft.tv;
 
-void MapChip::SetXY(POINT topLeftXY) {
-	Vertices<POINT> xy = GetXY(topLeftXY);
-	this->vertices.topLeft.x = xy.topLeft.x;
-	this->vertices.topLeft.y = xy.topLeft.y;
-	this->vertices.bottomRight.x = xy.bottomRight.x;
-	this->vertices.bottomRight.y = xy.bottomRight.y;
-}
-
-Vertices<Drawing::DrawingVertex> MapChip::CreateVertex() const {
-	return this->vertices;
+	pRet->bottomRight.x = this->vertices.bottomRight.x;
+	pRet->bottomRight.y = this->vertices.bottomRight.y;
+	pRet->bottomRight.tu = this->vertices.bottomRight.tu;
+	pRet->bottomRight.tv = this->vertices.bottomRight.tv;
 }
 
 
@@ -85,9 +86,10 @@ Vertices<Drawing::DrawingVertex> MapChip::CreateVertex() const {
 MapChip::MapChip(MapChipType chipType) : chipType(chipType) {}
 
 
-/* Private Functions  ------------------------------------------------------------------------------- */
-void MapChip::SetTuTv() {
-	Vertices<FloatPoint> tutv = GetTuTvs(this->chipNumber);
+/* Private Functions -------------------------------------------------------------------------------- */
+void MapChip::ConfigureTuTv() {
+	Vertices<FloatPoint> tutv;
+	ConvertChipNumberToTuTv(this->chipNumber, &tutv);
 	this->vertices.topLeft.tu = tutv.topLeft.x;
 	this->vertices.topLeft.tv = tutv.topLeft.y;
 	this->vertices.bottomRight.tu = tutv.bottomRight.x;

--- a/BestSteal_Replica/Map/MapChip.h
+++ b/BestSteal_Replica/Map/MapChip.h
@@ -21,15 +21,17 @@ public:
 
 	/* Static Functions --------------------------------------------------------------------------------- */
 	static MapChip* Create(MapChipType chipType);
-	static Vertices<FloatPoint> GetTuTvs(int mapChipNumber);
-	static Vertices<POINT> GetXY(POINT topLeftXY);
+	static void ConvertChipNumberToTuTv(int mapChipNumber, Vertices<FloatPoint>* pRet);
+	static void ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
 	MapChipType GetChipType() const;
+	void GetTopLeftXY(POINT* pRet) const;
+	void SetXY(const POINT& rTopLeftXY);
+
+	/* Functions ---------------------------------------------------------------------------------------- */
 	virtual void AssignChipNumber();
-	POINT GetTopLeftXY() const;
-	void SetXY(POINT topLeftXY);
-	Vertices<Drawing::DrawingVertex> CreateVertex() const;
+	void CreateDrawingVertices(Vertices<Drawing::DrawingVertex>* pRet) const;
 
 protected:
 	/* Structs ------------------------------------------------------------------------------------------ */
@@ -68,7 +70,7 @@ protected:
 	explicit MapChip(MapChipType chipType);
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void SetTuTv();
+	void ConfigureTuTv();
 };
 
 }

--- a/BestSteal_Replica/Map/MapChipGate.cpp
+++ b/BestSteal_Replica/Map/MapChipGate.cpp
@@ -38,7 +38,7 @@ void MapChipGate::OpenGate() {
 		default:
 			break;
 	}
-	SetTuTv();
+	ConfigureTuTv();
 }
 
 }

--- a/BestSteal_Replica/Map/MapChipJewelry.cpp
+++ b/BestSteal_Replica/Map/MapChipJewelry.cpp
@@ -19,7 +19,7 @@ void MapChipJewelry::OpenBox() {
 	if (this->state == MapChipJewelry::State::CLOSED) {
 		++this->chipNumber;
 		this->state = MapChipJewelry::State::OPENED;
-		SetTuTv();
+		ConfigureTuTv();
 	}
 }
 

--- a/BestSteal_Replica/Map/MapChipWall.cpp
+++ b/BestSteal_Replica/Map/MapChipWall.cpp
@@ -78,7 +78,7 @@ void MapChipWall::AssignChipNumber() {
 		}
 	}
 	// テクスチャー上のマップチップの位置
-	SetTuTv();
+	ConfigureTuTv();
 }
 
 void MapChipWall::SetNeedsTopLine() {

--- a/BestSteal_Replica/Map/Stone.h
+++ b/BestSteal_Replica/Map/Stone.h
@@ -21,20 +21,20 @@ public:
 	};
 
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Stone(POINT topLeftXY, AppCommon::Direction direction);
+	Stone(const POINT& rTopLeftXY, AppCommon::Direction direction);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	void SetTopLeftXY(POINT xy);
+	void SetTopLeftXY(const POINT& rXY);
 	State GetState() const;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void Stone::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pDrawingContexts) const;
 	void KeepBeingThrown();
 	bool Exists() const;
-	void Move(POINT xy);
-	Vertices<POINT> GetXYsOnGround() const;
+	void Move(const POINT& rXY);
+	void CalcXYsOnGround(Vertices<POINT>* pRet) const;
 	void SetDropped();
-	void BackOnePixcel();
+	void BackOnePixel();
 
 private:
 	/* Constants ---------------------------------------------------------------------------------------- */
@@ -50,7 +50,7 @@ private:
 	static const int GRAVITY = 2;
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	POINT defaultTopleftXY;
+	POINT defaultTopLeftXY;
 	POINT topLeftXY;
 	AppCommon::Direction direction;
 	Vertices<FloatPoint> tutv;
@@ -60,8 +60,7 @@ private:
 	POINT topLeftXYOnGnd;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	Vertices<Drawing::DrawingVertex> CreateVertex() const;
-
+	Vertices<Drawing::DrawingVertex> CreateDrawingVertices() const;
 };
 
 }

--- a/BestSteal_Replica/SceneController.cpp
+++ b/BestSteal_Replica/SceneController.cpp
@@ -10,22 +10,21 @@
 namespace BestStealReplica {
 
 /* Constructor / Destructor ------------------------------------------------------------------------- */
-SceneController::SceneController() : 
-	pStage(nullptr),
-	pStageController(new StageController()),
-	blackoutFrameCount(0) 
-{}
+SceneController::SceneController() : pStage(nullptr), pStageController(new StageController()), blackoutFrameCount(0) {}
 
 void SceneController::Release() {
+	if (this->pStage != nullptr) {
+		delete this->pStage;
+		this->pStage = nullptr;
+	}
 	delete this->pStageController;
-	delete this->pStage;
 }
 
 
 /* Public Functions  -------------------------------------------------------------------------------- */
 void SceneController::StartStage() {
 	this->pStage = new Stage::Stage1();
-	this->pStageController->LoadStage(*pStage);
+	this->pStageController->LoadStage(*this->pStage);
 	AppCommon::SetScene(AppCommon::SceneType::DRAWING_MAP);
 }
 

--- a/BestSteal_Replica/Stage/IStage.h
+++ b/BestSteal_Replica/Stage/IStage.h
@@ -17,7 +17,7 @@ public:
 	virtual int GetYChipCount() const = 0;
 	virtual int GetXChipCount() const = 0;
 	virtual Map::MapChipType GetMapChipType(int y, int x) const = 0;
-	virtual POINT GetPlayerFirstChipPos() const = 0;
+	virtual void GetPlayerFirstChipPos(POINT* pRet) const = 0;
 	virtual std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const = 0;
 	virtual int GetEnemyScoutableRadius() const = 0;
 	virtual int GetMaxStoneCount() const = 0;

--- a/BestSteal_Replica/Stage/Stage1.cpp
+++ b/BestSteal_Replica/Stage/Stage1.cpp
@@ -59,11 +59,9 @@ Map::MapChipType Stage1::GetMapChipType(int y, int x) const {
 	return mapChipTypes[y][x];
 }
 
-POINT Stage1::GetPlayerFirstChipPos() const {
-	POINT ret;
-	ret.x = 14;
-	ret.y = 20;
-	return ret;
+void Stage1::GetPlayerFirstChipPos(POINT* pRet) const {
+	pRet->x = 14;
+	pRet->y = 20;
 }
 
 std::vector<Enemy::EnemyInfo> Stage1::GetEnemiesInfo() const {

--- a/BestSteal_Replica/Stage/Stage1.h
+++ b/BestSteal_Replica/Stage/Stage1.h
@@ -13,7 +13,7 @@ public:
 	int GetYChipCount() const;
 	int GetXChipCount() const;
 	Map::MapChipType GetMapChipType(int y, int x) const;
-	POINT GetPlayerFirstChipPos() const;
+	void GetPlayerFirstChipPos(POINT* pRet) const;
 	std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const;
 	int GetEnemyScoutableRadius() const;
 	int GetMaxStoneCount() const;


### PR DESCRIPTION
- 返却値が構造体の関数はポインタでのout引数に変更
- 引数が構造体の関数はconst参照型に変更
- out引数の引数名はpRetにする
- 以下気付いた部分をついで変更
    - 処理変更、修正
        - 描画範囲外の判定が誤っていたので修正
        - 敵とプレイヤーの位置が重なっているかの判定が誤っていたので修正し、共通関数化
        - 二重開放があったので修正
        - プレイヤー、敵の中央座標を取得する箇所が複数あったのでそれぞれ関数化
    - 体裁変更
        - モノステートパターンクラスのprivate定数は無名名前空間に定義するように変更
        - getter/setter以外では関数名にget、setはできるだけ使わないようにする
        - メンバイニシャライザはできるだけ1行で書くようにする
        - 空コンストラクタはdefaultキーワードで定義する
        - 不要なコンストラクタ削除
        - インスタンス変数呼び出し時は`this`キーワードを付ける