### PR TITLE
[issue #16]座標関係の変数名変更

### DIFF
--- a/BestSteal_Replica/AppCommon.h
+++ b/BestSteal_Replica/AppCommon.h
@@ -24,7 +24,7 @@ struct FloatPoint {
 	FloatPoint(float x, float y);
 };
 
-template<typename T> struct Vertices {
+template<typename T> struct Rectangle {
 	T topLeft;
 	T bottomRight;
 };

--- a/BestSteal_Replica/Character/CharacterCommon.cpp
+++ b/BestSteal_Replica/Character/CharacterCommon.cpp
@@ -5,13 +5,13 @@ namespace BestStealReplica {
 namespace Character {
 
 /* Static Public Functions -------------------------------------------------------------------------- */
-void CharacterCommon::CreateChipTuTvs(int chipCount, int rowIdx, int colIdx, Vertices<FloatPoint> pRetArr[]) {
+void CharacterCommon::CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<FloatPoint> pRetArr[]) {
 	for (int i = 0; i < chipCount; ++i) {
-		CreateTuTv(rowIdx, colIdx + i, pRetArr + i);
+		CreateTexRect(rowIdx, colIdx + i, pRetArr + i);
 	}
 }
 
-void CharacterCommon::CreateTuTv(int rowIdx, int colIdx, Vertices<FloatPoint>* pRet) {
+void CharacterCommon::CreateTexRect(int rowIdx, int colIdx, Rectangle<FloatPoint>* pRet) {
 	pRet->topLeft.x = colIdx / (float)CharacterCommon::CHIP_COUNT_PER_COL;
 	pRet->topLeft.y = rowIdx / (float)CharacterCommon::CHIP_COUNT_PER_ROW;
 	pRet->bottomRight.x = (colIdx + 1) / (float)CharacterCommon::CHIP_COUNT_PER_COL;
@@ -29,30 +29,30 @@ int CharacterCommon::GetAnimationNumber(int currentAnimationCnt) {
 	return currentAnimationCnt / AppCommon::FRAME_COUNT_PER_CUT;
 }
 
-void CharacterCommon::CreateDrawingVertices(const POINT& rTopLeftXY, void(*convertTopLeftToVertices)(const POINT&, Vertices<POINT>*), const Vertices<FloatPoint>& rChip, Vertices<Drawing::DrawingVertex>* pRet) {
-	Vertices<POINT> xy;
-	convertTopLeftToVertices(rTopLeftXY, &xy);
+void CharacterCommon::CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<FloatPoint>& rChip, Rectangle<Drawing::DrawingVertex>* pRet) {
+	Rectangle<POINT> rect;
+	convertTopLeftToRect(rTopLeftPoint, &rect);
 
-	pRet->topLeft.x = xy.topLeft.x;
-	pRet->topLeft.y = xy.topLeft.y;
+	pRet->topLeft.x = rect.topLeft.x;
+	pRet->topLeft.y = rect.topLeft.y;
 	pRet->topLeft.tu = rChip.topLeft.x;
 	pRet->topLeft.tv = rChip.topLeft.y;
 
-	pRet->bottomRight.x = xy.bottomRight.x;
-	pRet->bottomRight.y = xy.bottomRight.y;
+	pRet->bottomRight.x = rect.bottomRight.x;
+	pRet->bottomRight.y = rect.bottomRight.y;
 	pRet->bottomRight.tu = rChip.bottomRight.x;
 	pRet->bottomRight.tv = rChip.bottomRight.y;
 }
 
-void CharacterCommon::ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet) {
-	pRet->topLeft.x = rTopLeftXY.x;
-	pRet->topLeft.y = rTopLeftXY.y;
-	pRet->bottomRight.x = rTopLeftXY.x + CharacterCommon::WIDTH - 1;
-	pRet->bottomRight.y = rTopLeftXY.y + CharacterCommon::HEIGHT - 1;
+void CharacterCommon::ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet) {
+	pRet->topLeft.x = rTopLeftPoint.x;
+	pRet->topLeft.y = rTopLeftPoint.y;
+	pRet->bottomRight.x = rTopLeftPoint.x + CharacterCommon::WIDTH - 1;
+	pRet->bottomRight.y = rTopLeftPoint.y + CharacterCommon::HEIGHT - 1;
 }
 
-void CharacterCommon::CalcCharacterXY(const POINT& rTopLeftXY, int width, int height, Vertices<POINT>* pRet) {
-	ConvertTopLeftXYToVertices(rTopLeftXY, pRet);
+void CharacterCommon::CalcCharacterRect(const POINT& rTopLeftPoint, int width, int height, Rectangle<POINT>* pRet) {
+	ConvertTopLeftPointToRect(rTopLeftPoint, pRet);
 	int xDiff = (CharacterCommon::WIDTH - width) / 2;
 	int yDiff = (CharacterCommon::HEIGHT - height) / 2;
 	pRet->topLeft.x += xDiff;
@@ -61,18 +61,18 @@ void CharacterCommon::CalcCharacterXY(const POINT& rTopLeftXY, int width, int he
 	pRet->bottomRight.y -= yDiff;
 }
 
-void CharacterCommon::CalcCenter(const Vertices<POINT>& rXY, POINT* pRet) {
-	pRet->x = rXY.topLeft.x + (rXY.bottomRight.x - rXY.topLeft.x) / 2;
-	pRet->y = rXY.topLeft.y + (rXY.bottomRight.y - rXY.topLeft.y) / 2;
+void CharacterCommon::CalcCenter(const Rectangle<POINT>& rRect, POINT* pRet) {
+	pRet->x = rRect.topLeft.x + (rRect.bottomRight.x - rRect.topLeft.x) / 2;
+	pRet->y = rRect.topLeft.y + (rRect.bottomRight.y - rRect.topLeft.y) / 2;
 }
 
-double CharacterCommon::CalcDistance(const POINT& rXY1, const POINT& rXY2) {
-	return sqrt(pow(rXY1.x - rXY2.x, 2.0) + pow(rXY1.y - rXY2.y, 2.0));
+double CharacterCommon::CalcDistance(const POINT& rPoint1, const POINT& rPoint2) {
+	return sqrt(pow(rPoint1.x - rPoint2.x, 2.0) + pow(rPoint1.y - rPoint2.y, 2.0));
 }
 
-bool CharacterCommon::IsOverlapping(const Vertices<POINT>& rXY1, const Vertices<POINT>& rXY2) {
-	return (rXY1.topLeft.x < rXY2.bottomRight.x && rXY2.topLeft.x < rXY1.bottomRight.x
-		&& rXY1.topLeft.y < rXY2.bottomRight.y && rXY2.topLeft.y < rXY1.bottomRight.y);
+bool CharacterCommon::IsOverlapping(const Rectangle<POINT>& rRect1, const Rectangle<POINT>& rRect2) {
+	return (rRect1.topLeft.x < rRect2.bottomRight.x && rRect2.topLeft.x < rRect1.bottomRight.x
+		&& rRect1.topLeft.y < rRect2.bottomRight.y && rRect2.topLeft.y < rRect1.bottomRight.y);
 }
 
 }

--- a/BestSteal_Replica/Character/CharacterCommon.h
+++ b/BestSteal_Replica/Character/CharacterCommon.h
@@ -15,16 +15,16 @@ public:
 	static const int WIDTH = 80;
 
 	/* Static Functions --------------------------------------------------------------------------------- */
-	static void CreateChipTuTvs(int chipCount, int rowIdx, int colIdx, Vertices<FloatPoint> pRetArr[]);
-	static void CreateTuTv(int rowIdx, int colIdx, Vertices<FloatPoint>* pRet);
+	static void CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<FloatPoint> pRetArr[]);
+	static void CreateTexRect(int rowIdx, int colIdx, Rectangle<FloatPoint>* pRet);
 	static void CountUpAnimationCnt(int* pAnimationCnt, int chipCntPerDir);
 	static int GetAnimationNumber(int currentAnimationCnt);
-	static void CreateDrawingVertices(const POINT& rTopLeftXY, void(*convertTopLeftToVertices)(const POINT&, Vertices<POINT>*), const Vertices<FloatPoint>& rChip, Vertices<Drawing::DrawingVertex>* pRet);
-	static void ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet);
-	static void CalcCharacterXY(const POINT& rTopLeftXY, int width, int height, Vertices<POINT>* pRet);
-	static void CalcCenter(const Vertices<POINT>& rXY, POINT* pRet);
-	static double CalcDistance(const POINT& rXY1, const POINT& rXY2);
-	static bool IsOverlapping(const Vertices<POINT>& rXY1, const Vertices<POINT>& rXY2);
+	static void CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<FloatPoint>& rChip, Rectangle<Drawing::DrawingVertex>* pRet);
+	static void ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet);
+	static void CalcCharacterRect(const POINT& rTopLeftPoint, int width, int height, Rectangle<POINT>* pRet);
+	static void CalcCenter(const Rectangle<POINT>& rRect, POINT* pRet);
+	static double CalcDistance(const POINT& rPoint1, const POINT& rPoint2);
+	static bool IsOverlapping(const Rectangle<POINT>& rRect1, const Rectangle<POINT>& rRect2);
 
 private:
 	/* Constants ---------------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/Character/Enemy.h
+++ b/BestSteal_Replica/Character/Enemy.h
@@ -29,8 +29,8 @@ public:
 	/* Structs ------------------------------------------------------------------------------------------ */
 	struct EnemyInfo {
 		POINT chipPos;
-		POINT topLeftXY;
-		POINT defaultTopLeftXY;
+		POINT topLeftPoint;
+		POINT defaultTopLeftPoint;
 		AppCommon::Direction defaultDirection;
 		AppCommon::Direction headingDirection;
 		AppCommon::GateKeyType holdingGateKey;
@@ -45,7 +45,7 @@ public:
 
 
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Enemy(std::vector<EnemyInfo> enemiesInfo, std::vector<POINT> topLeftXYs, int scoutableRadius);
+	Enemy(const std::vector<EnemyInfo>& rEnemiesInfo, const std::vector<POINT>& rTopLeftPoints, int scoutableRadius);
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
@@ -59,14 +59,14 @@ public:
 	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const;
 
 	void Stay();
-	void Move(const POINT& rXY);
-	void CalcEnemyXY(int enemyIdx, Vertices<POINT>* pRet) const;
-	void CalcCenterXY(int enemyIdx, POINT* pRet) const;
-	void ScoutStone(const std::vector<Vertices<POINT>>& rStonesXY);
+	void Move(const POINT& rPixel);
+	void CalcEnemyRect(int enemyIdx, Rectangle<POINT>* pRet) const;
+	void CalcCenter(int enemyIdx, POINT* pRet) const;
+	void ScoutStone(const std::vector<Rectangle<POINT>>& rStonesRect);
 	void ScoutPlayer(const POINT& rPlayerCenter, bool isPlayerWalking);
-	AppCommon::GateKeyType GetStolen(const Vertices<POINT>& rPlayerXY, bool isPlayerStealing);
+	AppCommon::GateKeyType GetStolen(const Rectangle<POINT>& rPlayerRect, bool isPlayerStealing);
 	void Attack(int enemyIdx, bool canSeePlayer);
-	bool CanKillPlayer(const Vertices<POINT>& rPlayerXY) const;
+	bool CanKillPlayer(const Rectangle<POINT>& rPlayerRect) const;
 	void BackToDefaultPosition();
 
 
@@ -91,19 +91,19 @@ private:
 
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	Vertices<FloatPoint> headingBottomChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingTopChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingLeftChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingRightChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> exclamationMarkChip;
+	Rectangle<FloatPoint> texRectOfHeadingBottomChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingTopChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingLeftChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingRightChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfExclamationMarkChip;
 
 	std::vector<EnemyInfo> enemiesInfo;
 	int scoutableRadius;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void CreateDrawingVertices(int enemyIdx, Vertices<Drawing::DrawingVertex>* pRet) const;
-	void TurnTo(const POINT& rTargetXY, int enemyIdx);
+	void CreateDrawingVertexRect(int enemyIdx, Rectangle<Drawing::DrawingVertex>* pRet) const;
+	void TurnTo(const POINT& rTargetPoint, int enemyIdx);
 
 };
 

--- a/BestSteal_Replica/Character/Player.h
+++ b/BestSteal_Replica/Character/Player.h
@@ -19,7 +19,7 @@ public:
 
 
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Player(POINT topLeftXY);
+	Player(const POINT& rTopLeftPoint);
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
@@ -36,13 +36,13 @@ public:
 	void Stay();
 	void StartStealing();
 	void KeepStealing();
-	void Move(const POINT& rXY);
+	void Move(const POINT& rPixel);
 	bool IsStayingNearlyWindowTop() const;
 	bool IsStayingNearlyWindowRight() const;
 	bool IsStayingNearlyWindowBottom() const;
 	bool IsStayingNearlyWindowLeft() const;
-	void CalcPlayerXY(Vertices<POINT>* pRet) const;
-	void CalcCenterXY(POINT* pRet) const;
+	void CalcPlayerRect(Rectangle<POINT>* pRet) const;
+	void CalcCenter(POINT* pRet) const;
 	bool HasGateKey(AppCommon::GateKeyType key) const;
 	void GainGateKey(AppCommon::GateKeyType key);
 	void LoseGateKey(AppCommon::GateKeyType key);
@@ -78,8 +78,8 @@ private:
 
 	/* Variables ---------------------------------------------------------------------------------------- */
 	int currentAnimationCnt;
-	POINT topLeftXY;
-	POINT defaultTopLeftXY;
+	POINT topLeftPoint;
+	POINT defaultTopLeftPoint;
 	int currentKeepingStealingNum;
 	bool hasDirectionChanged;
 	bool isStealing;
@@ -87,20 +87,20 @@ private:
 	int holdingGoldGateKeyCount;
 	int holdingSilverGateKeyCount;
 
-	Vertices<FloatPoint> headingBottomChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingTopChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingLeftChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> headingRightChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Vertices<FloatPoint> StealingBottomChip;
-	Vertices<FloatPoint> StealingTopChip;
-	Vertices<FloatPoint> StealingLeftChip;
-	Vertices<FloatPoint> StealingRightChip;
+	Rectangle<FloatPoint> texRectOfHeadingBottomChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingTopChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingLeftChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfHeadingRightChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<FloatPoint> texRectOfStealingBottomChip;
+	Rectangle<FloatPoint> texRectOfStealingTopChip;
+	Rectangle<FloatPoint> texRectOfStealingLeftChip;
+	Rectangle<FloatPoint> texRectOfStealingRightChip;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void ReturnPropertiesToDefault();
-	void CreateVertices(Vertices<Drawing::DrawingVertex>* pVertices) const;
-	void CalcVerticesOnStealing(int afterImageNum, Vertices<Drawing::DrawingVertex>* pVertices) const;
+	void CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const;
+	void CreateDrawingVertexRectOnStealing(int afterImageNum, Rectangle<Drawing::DrawingVertex>* pRet) const;
 	const int* GetHoldingGateKeyCnt(AppCommon::GateKeyType key) const;
 
 };

--- a/BestSteal_Replica/Drawing/Drawer.cpp
+++ b/BestSteal_Replica/Drawing/Drawer.cpp
@@ -160,41 +160,41 @@ void Drawer::BeginDraw() {
 }
 
 void Drawer::Draw(const DrawingContext& rContext) {
-	if (rContext.vertices.bottomRight.x < 0 || rContext.vertices.bottomRight.y < 0
-		|| rContext.vertices.topLeft.x > AppCommon::GetWindowWidth() || rContext.vertices.topLeft.y > AppCommon::GetWindowHeight()) {
+	if (rContext.rect.bottomRight.x < 0 || rContext.rect.bottomRight.y < 0
+		|| rContext.rect.topLeft.x > AppCommon::GetWindowWidth() || rContext.rect.topLeft.y > AppCommon::GetWindowHeight()) {
 		// 描画範囲外
 		return;
 	}
 
-	CUSTOMVERTEX customVertex[4];
-	for (auto& vertex : customVertex) {
+	CUSTOMVERTEX customVertexArr[4];
+	for (auto& vertex : customVertexArr) {
 		vertex.z = 0.5f;
 		vertex.rhw = 1.0f;
 		vertex.color = D3DCOLOR_ARGB(rContext.alpha, 255, 255, 255);
 	}
 
-	customVertex[0].x = (float)rContext.vertices.topLeft.x;
-	customVertex[0].y = (float)rContext.vertices.topLeft.y;
-	customVertex[0].tu = rContext.vertices.topLeft.tu;
-	customVertex[0].tv = rContext.vertices.topLeft.tv;
+	customVertexArr[0].x = (float)rContext.rect.topLeft.x;
+	customVertexArr[0].y = (float)rContext.rect.topLeft.y;
+	customVertexArr[0].tu = rContext.rect.topLeft.tu;
+	customVertexArr[0].tv = rContext.rect.topLeft.tv;
 
-	customVertex[1].x = (float)rContext.vertices.bottomRight.x;
-	customVertex[1].y = (float)rContext.vertices.topLeft.y;
-	customVertex[1].tu = rContext.vertices.bottomRight.tu;
-	customVertex[1].tv = rContext.vertices.topLeft.tv;
+	customVertexArr[1].x = (float)rContext.rect.bottomRight.x;
+	customVertexArr[1].y = (float)rContext.rect.topLeft.y;
+	customVertexArr[1].tu = rContext.rect.bottomRight.tu;
+	customVertexArr[1].tv = rContext.rect.topLeft.tv;
 
-	customVertex[2].x = (float)rContext.vertices.bottomRight.x;
-	customVertex[2].y = (float)rContext.vertices.bottomRight.y;
-	customVertex[2].tu = rContext.vertices.bottomRight.tu;
-	customVertex[2].tv = rContext.vertices.bottomRight.tv;
+	customVertexArr[2].x = (float)rContext.rect.bottomRight.x;
+	customVertexArr[2].y = (float)rContext.rect.bottomRight.y;
+	customVertexArr[2].tu = rContext.rect.bottomRight.tu;
+	customVertexArr[2].tv = rContext.rect.bottomRight.tv;
 
-	customVertex[3].x = (float)rContext.vertices.topLeft.x;
-	customVertex[3].y = (float)rContext.vertices.bottomRight.y;
-	customVertex[3].tu = rContext.vertices.topLeft.tu;
-	customVertex[3].tv = rContext.vertices.bottomRight.tv;
+	customVertexArr[3].x = (float)rContext.rect.topLeft.x;
+	customVertexArr[3].y = (float)rContext.rect.bottomRight.y;
+	customVertexArr[3].tu = rContext.rect.topLeft.tu;
+	customVertexArr[3].tv = rContext.rect.bottomRight.tv;
 
 	pD3Device->SetTexture(0, textures.at(rContext.textureType));
-	pD3Device->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, customVertex, sizeof(CUSTOMVERTEX));
+	pD3Device->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, customVertexArr, sizeof(CUSTOMVERTEX));
 }
 
 void Drawer::EndDraw() {

--- a/BestSteal_Replica/Drawing/DrawingCommon.h
+++ b/BestSteal_Replica/Drawing/DrawingCommon.h
@@ -23,7 +23,7 @@ enum TextureType {
 
 /* Structs ------------------------------------------------------------------------------------------ */
 struct DrawingContext {
-	Vertices<DrawingVertex> vertices;
+	Rectangle<DrawingVertex> rect;
 	TextureType textureType;
 	UINT16 alpha = 0xFF;
 };

--- a/BestSteal_Replica/Map/Map.h
+++ b/BestSteal_Replica/Map/Map.h
@@ -38,22 +38,22 @@ public:
 	void CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const;
 
 	void Load(const Stage::IStage& rStage);
-	void Move(const POINT& rXY);
+	void Move(const POINT& rPixel);
 	void MoveToDefault();
 	bool IsMovableX(int x) const;
 	bool IsMovableY(int y) const;
-	bool IsOnRoad(const Vertices<POINT>& rXY) const;
-	void ConvertMapChipPosToTopLeftXY(const POINT& rMapChipPos, POINT* pRet) const;
+	bool IsOnRoad(const Rectangle<POINT>& rRect) const;
+	void ConvertMapChipPosToTopLeftPoint(const POINT& rCharacterRect, POINT* pRet) const;
 	void KeepOpeningGates();
-	void ConvertToCharacterFrontMapChipPos(const Vertices<POINT>& rPlayerXY, AppCommon::Direction headingDirection, POINT* pRet) const;
+	void ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRect, AppCommon::Direction headingDirection, POINT* pRet) const;
 	bool StartOpeningGate(const POINT& rMapChipPos);
 	bool IsGateOpened(const POINT& rMapChipPos) const;
-	bool ExistsWallBetween(const POINT& rXY1, const POINT& rXY2) const;
+	bool ExistsWallBetween(const POINT& rPoint1, const POINT& rPoint2) const;
 	void OpenJewelryBox();
-	void ConvertToMapChipPos(const POINT& rXY, POINT* pRet) const;
-	void AddStone(const POINT& rTopLeftXY, AppCommon::Direction direction);
+	void ConvertToMapChipPos(const POINT& rPoint, POINT* pRet) const;
+	void AddStone(const POINT& rTopLeftPoint, AppCommon::Direction direction);
 	void AnimateStones();
-	void CalcDroppedStoneXYs(std::vector<Vertices<POINT>>* pRet) const;
+	void CalcDroppedStonesRect(std::vector<Rectangle<POINT>>* pRet) const;
 
 
 private:
@@ -62,8 +62,8 @@ private:
 
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	POINT defaultTopLeft;
-	POINT topLeft;
+	POINT defaultTopLeftPoint;
+	POINT topLeftPoint;
 	DataTable<MapChip*> pMapData;
 	std::vector<MapChipGate*> pGateMapChips;
 	MapChipJewelry* pJewelryMapChip;
@@ -72,7 +72,7 @@ private:
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void AssignChipNumber();
-	void ConfigureChipXY();
+	void ConfigureChipPoint();
 	bool IsOnRoad(const POINT& rMapChipPos) const;
 	bool IsMovable(int targetPoint, int topLeftPoint, int mapChipCount, int mapChipSize, int windowSize) const;
 };

--- a/BestSteal_Replica/Map/MapChip.cpp
+++ b/BestSteal_Replica/Map/MapChip.cpp
@@ -25,7 +25,7 @@ MapChip* MapChip::Create(MapChipType chipType) {
 	}
 }
 
-void MapChip::ConvertChipNumberToTuTv(int mapChipNumber, Vertices<FloatPoint>* pRet) {
+void MapChip::ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<FloatPoint>* pRet) {
 	int chipPosX = mapChipNumber % CHIP_COUNT_PER_ROW;
 	int chipPosY = mapChipNumber / CHIP_COUNT_PER_ROW;
 
@@ -35,11 +35,11 @@ void MapChip::ConvertChipNumberToTuTv(int mapChipNumber, Vertices<FloatPoint>* p
 	pRet->bottomRight.y = (float)(chipPosY + 1) / (float)CHIP_COUNT_PER_COL;
 }
 
-void MapChip::ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet) {
-	pRet->topLeft.x = rTopLeftXY.x;
-	pRet->topLeft.y = rTopLeftXY.y;
-	pRet->bottomRight.x = rTopLeftXY.x + MapChip::WIDTH;
-	pRet->bottomRight.y = rTopLeftXY.y + MapChip::HEIGHT;
+void MapChip::ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet) {
+	pRet->topLeft.x = rTopLeftPoint.x;
+	pRet->topLeft.y = rTopLeftPoint.y;
+	pRet->bottomRight.x = rTopLeftPoint.x + MapChip::WIDTH;
+	pRet->bottomRight.y = rTopLeftPoint.y + MapChip::HEIGHT;
 }
 
 
@@ -48,16 +48,16 @@ MapChipType MapChip::GetChipType() const {
 	return this->chipType;
 }
 
-void MapChip::GetTopLeftXY(POINT* pRet) const {
-	pRet->x = this->vertices.topLeft.x;
-	pRet->y = this->vertices.topLeft.y;
+void MapChip::GetTopLeftPoint(POINT* pRet) const {
+	pRet->x = this->drawingVertexRect.topLeft.x;
+	pRet->y = this->drawingVertexRect.topLeft.y;
 }
 
-void MapChip::SetXY(const POINT& rTopLeftXY) {
-	this->vertices.topLeft.x = rTopLeftXY.x;
-	this->vertices.topLeft.y = rTopLeftXY.y;
-	this->vertices.bottomRight.x = rTopLeftXY.x + MapChip::WIDTH;
-	this->vertices.bottomRight.y = rTopLeftXY.y + MapChip::HEIGHT;
+void MapChip::SetTopLeftPoint(const POINT& rTopLeftPoint) {
+	this->drawingVertexRect.topLeft.x = rTopLeftPoint.x;
+	this->drawingVertexRect.topLeft.y = rTopLeftPoint.y;
+	this->drawingVertexRect.bottomRight.x = rTopLeftPoint.x + MapChip::WIDTH;
+	this->drawingVertexRect.bottomRight.y = rTopLeftPoint.y + MapChip::HEIGHT;
 }
 
 
@@ -66,19 +66,19 @@ void MapChip::AssignChipNumber() {
 	this->chipNumber = (int)this->chipType;
 
 	// テクスチャー上のマップチップの位置
-	ConfigureTuTv();
+	ConfigureTexRect();
 }
 
-void MapChip::CreateDrawingVertices(Vertices<Drawing::DrawingVertex>* pRet) const {
-	pRet->topLeft.x = this->vertices.topLeft.x;
-	pRet->topLeft.y = this->vertices.topLeft.y;
-	pRet->topLeft.tu = this->vertices.topLeft.tu;
-	pRet->topLeft.tv = this->vertices.topLeft.tv;
+void MapChip::CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const {
+	pRet->topLeft.x = this->drawingVertexRect.topLeft.x;
+	pRet->topLeft.y = this->drawingVertexRect.topLeft.y;
+	pRet->topLeft.tu = this->drawingVertexRect.topLeft.tu;
+	pRet->topLeft.tv = this->drawingVertexRect.topLeft.tv;
 
-	pRet->bottomRight.x = this->vertices.bottomRight.x;
-	pRet->bottomRight.y = this->vertices.bottomRight.y;
-	pRet->bottomRight.tu = this->vertices.bottomRight.tu;
-	pRet->bottomRight.tv = this->vertices.bottomRight.tv;
+	pRet->bottomRight.x = this->drawingVertexRect.bottomRight.x;
+	pRet->bottomRight.y = this->drawingVertexRect.bottomRight.y;
+	pRet->bottomRight.tu = this->drawingVertexRect.bottomRight.tu;
+	pRet->bottomRight.tv = this->drawingVertexRect.bottomRight.tv;
 }
 
 
@@ -87,13 +87,13 @@ MapChip::MapChip(MapChipType chipType) : chipType(chipType) {}
 
 
 /* Private Functions -------------------------------------------------------------------------------- */
-void MapChip::ConfigureTuTv() {
-	Vertices<FloatPoint> tutv;
-	ConvertChipNumberToTuTv(this->chipNumber, &tutv);
-	this->vertices.topLeft.tu = tutv.topLeft.x;
-	this->vertices.topLeft.tv = tutv.topLeft.y;
-	this->vertices.bottomRight.tu = tutv.bottomRight.x;
-	this->vertices.bottomRight.tv = tutv.bottomRight.y;
+void MapChip::ConfigureTexRect() {
+	Rectangle<FloatPoint> texRect;
+	ConvertChipNumberToTexRect(this->chipNumber, &texRect);
+	this->drawingVertexRect.topLeft.tu = texRect.topLeft.x;
+	this->drawingVertexRect.topLeft.tv = texRect.topLeft.y;
+	this->drawingVertexRect.bottomRight.tu = texRect.bottomRight.x;
+	this->drawingVertexRect.bottomRight.tv = texRect.bottomRight.y;
 }
 
 }

--- a/BestSteal_Replica/Map/MapChip.h
+++ b/BestSteal_Replica/Map/MapChip.h
@@ -21,17 +21,17 @@ public:
 
 	/* Static Functions --------------------------------------------------------------------------------- */
 	static MapChip* Create(MapChipType chipType);
-	static void ConvertChipNumberToTuTv(int mapChipNumber, Vertices<FloatPoint>* pRet);
-	static void ConvertTopLeftXYToVertices(const POINT& rTopLeftXY, Vertices<POINT>* pRet);
+	static void ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<FloatPoint>* pRet);
+	static void ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
 	MapChipType GetChipType() const;
-	void GetTopLeftXY(POINT* pRet) const;
-	void SetXY(const POINT& rTopLeftXY);
+	void GetTopLeftPoint(POINT* pRet) const;
+	void SetTopLeftPoint(const POINT& rTopLeftPoint);
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	virtual void AssignChipNumber();
-	void CreateDrawingVertices(Vertices<Drawing::DrawingVertex>* pRet) const;
+	void CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const;
 
 protected:
 	/* Structs ------------------------------------------------------------------------------------------ */
@@ -64,13 +64,13 @@ protected:
 	/* Variables ---------------------------------------------------------------------------------------- */
 	MapChipType chipType;
 	int chipNumber;
-	Vertices<Drawing::DrawingVertex> vertices;
+	Rectangle<Drawing::DrawingVertex> drawingVertexRect;
 
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
 	explicit MapChip(MapChipType chipType);
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void ConfigureTuTv();
+	void ConfigureTexRect();
 };
 
 }

--- a/BestSteal_Replica/Map/MapChipGate.cpp
+++ b/BestSteal_Replica/Map/MapChipGate.cpp
@@ -38,7 +38,7 @@ void MapChipGate::OpenGate() {
 		default:
 			break;
 	}
-	ConfigureTuTv();
+	ConfigureTexRect();
 }
 
 }

--- a/BestSteal_Replica/Map/MapChipJewelry.cpp
+++ b/BestSteal_Replica/Map/MapChipJewelry.cpp
@@ -19,7 +19,7 @@ void MapChipJewelry::OpenBox() {
 	if (this->state == MapChipJewelry::State::CLOSED) {
 		++this->chipNumber;
 		this->state = MapChipJewelry::State::OPENED;
-		ConfigureTuTv();
+		ConfigureTexRect();
 	}
 }
 

--- a/BestSteal_Replica/Map/MapChipWall.cpp
+++ b/BestSteal_Replica/Map/MapChipWall.cpp
@@ -78,7 +78,7 @@ void MapChipWall::AssignChipNumber() {
 		}
 	}
 	// テクスチャー上のマップチップの位置
-	ConfigureTuTv();
+	ConfigureTexRect();
 }
 
 void MapChipWall::SetNeedsTopLine() {

--- a/BestSteal_Replica/Map/Stone.h
+++ b/BestSteal_Replica/Map/Stone.h
@@ -21,18 +21,18 @@ public:
 	};
 
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
-	Stone(const POINT& rTopLeftXY, AppCommon::Direction direction);
+	Stone(const POINT& rTopLeftPoint, AppCommon::Direction direction);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	void SetTopLeftXY(const POINT& rXY);
+	void SetTopLeftPoint(const POINT& rPoint);
 	State GetState() const;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void Stone::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pDrawingContexts) const;
 	void KeepBeingThrown();
 	bool Exists() const;
-	void Move(const POINT& rXY);
-	void CalcXYsOnGround(Vertices<POINT>* pRet) const;
+	void Move(const POINT& rPixel);
+	void CalcRectOnGround(Rectangle<POINT>* pRet) const;
 	void SetDropped();
 	void BackOnePixel();
 
@@ -50,17 +50,17 @@ private:
 	static const int GRAVITY = 2;
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	POINT defaultTopLeftXY;
-	POINT topLeftXY;
+	POINT defaultTopLeftPoint;
+	POINT topLeftPoint;
 	AppCommon::Direction direction;
-	Vertices<FloatPoint> tutv;
+	Rectangle<FloatPoint> texRect;
 	int thrownElapsedCount;
 	Stone::State state;
 	int restTime;
-	POINT topLeftXYOnGnd;
+	POINT topLeftPointOnGnd;
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void Stone::CreateDrawingVertices(Vertices<Drawing::DrawingVertex>* pRet) const;
+	void Stone::CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const;
 };
 
 }

--- a/BestSteal_Replica/Stage/IStage.h
+++ b/BestSteal_Replica/Stage/IStage.h
@@ -18,7 +18,7 @@ public:
 	virtual int GetXChipCount() const = 0;
 	virtual Map::MapChipType GetMapChipType(int y, int x) const = 0;
 	virtual void GetPlayerFirstChipPos(POINT* pRet) const = 0;
-	virtual std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const = 0;
+	virtual void GetEnemiesInfo(std::vector<Character::Enemy::EnemyInfo>* pRet) const = 0;
 	virtual int GetEnemyScoutableRadius() const = 0;
 	virtual int GetMaxStoneCount() const = 0;
 };

--- a/BestSteal_Replica/Stage/Stage1.cpp
+++ b/BestSteal_Replica/Stage/Stage1.cpp
@@ -64,8 +64,10 @@ void Stage1::GetPlayerFirstChipPos(POINT* pRet) const {
 	pRet->y = 20;
 }
 
-std::vector<Enemy::EnemyInfo> Stage1::GetEnemiesInfo() const {
-	return enemiesInfo;
+void Stage1::GetEnemiesInfo(std::vector<Enemy::EnemyInfo>* pRet) const {
+	for (auto& enemy : enemiesInfo) {
+		pRet->push_back(enemy);
+	}
 }
 
 int Stage1::GetEnemyScoutableRadius() const {

--- a/BestSteal_Replica/Stage/Stage1.h
+++ b/BestSteal_Replica/Stage/Stage1.h
@@ -14,7 +14,7 @@ public:
 	int GetXChipCount() const;
 	Map::MapChipType GetMapChipType(int y, int x) const;
 	void GetPlayerFirstChipPos(POINT* pRet) const;
-	std::vector<Character::Enemy::EnemyInfo> GetEnemiesInfo() const;
+	void GetEnemiesInfo(std::vector<Character::Enemy::EnemyInfo>* pRet) const;
 	int GetEnemyScoutableRadius() const;
 	int GetMaxStoneCount() const;
 


### PR DESCRIPTION
- 構造体`Vertices`を`Rectangle`に名前変更
- `POINT`型を使用している箇所の名前をXYからPoint又はPixelに変更
- `Vertices<POINT>`型を使用している箇所の名前をXYからRectに変更
- `Vertices<DrawingVertex>`型を使用している箇所の名前をDrawingVerticesからDrawingVertexRectに変更
- `Vertices<FloatPoint>`型を使用している箇所の名前を`TuTv(s)からTexRectに変更
- `Vertices<FloatPoint>[]`型の変数名をChipsからTexRectOfFooChipsに変更
- ついでにissue #11 の対応漏れも変更