### PR TITLE
[issue #25]警告レベルを最大にして警告が表示されないようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,26 +4,34 @@
 # User-specific files
 *.suo
 *.user
+*.userosscache
 *.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
 
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
+[Rr]eleases/
 x64/
-build/
+x86/
 bld/
 [Bb]in/
 [Oo]bj/
+[Ll]og/
 
-# Roslyn cache directories
-*.ide/
+# Visual Studio 2015 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
-#NUNIT
+# NUNIT
 *.VisualState.xml
 TestResult.xml
 
@@ -31,6 +39,11 @@ TestResult.xml
 [Dd]ebugPS/
 [Rr]eleasePS/
 dlldata.c
+
+# DNX
+project.lock.json
+project.fragment.lock.json
+artifacts/
 
 *_i.c
 *_p.c
@@ -64,14 +77,18 @@ _Chutzpah*
 ipch/
 *.aps
 *.ncb
+*.opendb
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.db
+*.VC.VC.opendb
 
 # Visual Studio profiler
 *.psess
 *.vsp
 *.vspx
+*.sap
 
 # TFS 2012 Local Workspace
 $tf/
@@ -84,7 +101,7 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
-# JustCode is a .NET coding addin-in
+# JustCode is a .NET coding add-in
 .JustCode
 
 # TeamCity is a build add-in
@@ -96,6 +113,7 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+nCrunchTemp_*
 
 # MightyMoose
 *.mm.*
@@ -123,42 +141,63 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-## TODO: Comment the next line if you want to checkin your
-## web deploy settings but do note that will include unencrypted
-## passwords
+# TODO: Comment the next line if you want to checkin your web deploy settings
+# but database connection strings (with potential passwords) will be unencrypted
 #*.pubxml
+*.publishproj
 
-# NuGet Packages Directory
-packages/*
-## TODO: If the tool you use requires repositories.config
-## uncomment the next line
-#!packages/repositories.config
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
 
-# Enable "build/" folder in the NuGet Packages folder since
-# NuGet packages use it for MSBuild targets.
-# This line needs to be after the ignore of the build folder
-# (and the packages folder if the line above has been uncommented)
-!packages/build/
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/packages/repositories.config
+# NuGet v3's project.json files produces more ignoreable files
+*.nuget.props
+*.nuget.targets
 
-# Windows Azure Build Output
+# Microsoft Azure Build Output
 csx/
 *.build.csdef
 
-# Windows Store app package directory
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
 AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/
 
 # Others
-sql/
-*.Cache
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/
+orleans.codegen.cs
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
 
 # RIA/Silverlight projects
 Generated_Code/
@@ -183,7 +222,40 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
-# LightSwitch generated files
-GeneratedArtifacts/
-_Pvt_Extensions/
-ModelManifest.xml
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+# CodeRush
+.cr/
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+*.pyc

--- a/BestSteal_Replica/AppCommon.cpp
+++ b/BestSteal_Replica/AppCommon.cpp
@@ -9,7 +9,8 @@ static AppCommon::SceneType scene;
 }
 
 /* Constructor / Destructor ------------------------------------------------------------------------- */
-FloatPoint::FloatPoint(float x, float y) : x(x), y(y) {}
+template<typename T>
+Point<T>::Point(T x, T y) : x(x), y(y) {}
 
 
 /* Getters / Setters -------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/AppCommon.h
+++ b/BestSteal_Replica/AppCommon.h
@@ -1,36 +1,30 @@
 ﻿#ifndef APP_COMMON_H_
 #define APP_COMMON_H_
 
-#include <vector>
-#include <windows.h>
-
-// new演算子をオーバーロードしているクラスはcrtdbg.hより前にincludeする必要有
-#include <d3dx9math.h>
-
-#if _DEBUG
-#define _CRTDBG_MAP_ALLOC
-#include <crtdbg.h>
-#define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
-#endif
-
 
 namespace BestStealReplica {
 
-struct FloatPoint {
-	float x;
-	float y;
+/**
+ * Point構造体のジェネリック型
+ *
+ * 当構造体はコピー可能とする。
+ */
+template<typename T> struct Point {
+	T x;
+	T y;
 
-	FloatPoint() = default;
-	FloatPoint(float x, float y);
-	FloatPoint(const FloatPoint&) = delete;
+	Point() = default;
+	Point(T x, T y);
 };
 
+/**
+ * 四角形の頂点情報を保有する構造体
+ *
+ * 当構造体はコピー可能とする。
+ */
 template<typename T> struct Rectangle {
 	T topLeft;
 	T bottomRight;
-
-	Rectangle() = default;
-	Rectangle(const Rectangle&) = default;
 };
 
 template<typename T>

--- a/BestSteal_Replica/BestSteal_Replica.vcxproj
+++ b/BestSteal_Replica/BestSteal_Replica.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -13,18 +13,19 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DC6EDB53-EFE1-416D-B788-1DC184376622}</ProjectGuid>
     <RootNamespace>BestSteal_Replica</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -39,15 +40,24 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDIr);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4710;4061;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ShowIncludes>false</ShowIncludes>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -56,17 +66,23 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDIr);$(ProjectDIr)Character;$(ProjectDIr)Map;$(ProjectDIr)Stage;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ShowIncludes>false</ShowIncludes>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4710;4061;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>winmm.lib;d3d9.lib;d3dx9.lib;dinput8.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -86,6 +102,12 @@
     <ClCompile Include="Map\MapChipGate.cpp" />
     <ClCompile Include="Map\MapChipWall.cpp" />
     <ClCompile Include="Stage\Stage1.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4710;4820;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4710;4820;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppCommon.h" />
@@ -105,6 +127,7 @@
     <ClInclude Include="Character\Player.h" />
     <ClInclude Include="StageController.h" />
     <ClInclude Include="Stage\Stage1.h" />
+    <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/BestSteal_Replica/BestSteal_Replica.vcxproj.filters
+++ b/BestSteal_Replica/BestSteal_Replica.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="Map\MapChipGate.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppCommon.h">
@@ -126,6 +129,9 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="Map\MapChipGate.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="stdafx.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/BestSteal_Replica/Character/CharacterCommon.cpp
+++ b/BestSteal_Replica/Character/CharacterCommon.cpp
@@ -5,13 +5,13 @@ namespace BestStealReplica {
 namespace Character {
 
 /* Static Public Functions -------------------------------------------------------------------------- */
-void CharacterCommon::CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<FloatPoint> pRetArr[]) {
+void CharacterCommon::CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<Point<float>> pRetArr[]) {
 	for (int i = 0; i < chipCount; ++i) {
 		CreateTexRect(rowIdx, colIdx + i, pRetArr + i);
 	}
 }
 
-void CharacterCommon::CreateTexRect(int rowIdx, int colIdx, Rectangle<FloatPoint>* pRet) {
+void CharacterCommon::CreateTexRect(int rowIdx, int colIdx, Rectangle<Point<float>>* pRet) {
 	pRet->topLeft.x = colIdx / (float)CharacterCommon::CHIP_COUNT_PER_COL;
 	pRet->topLeft.y = rowIdx / (float)CharacterCommon::CHIP_COUNT_PER_ROW;
 	pRet->bottomRight.x = (colIdx + 1) / (float)CharacterCommon::CHIP_COUNT_PER_COL;
@@ -29,7 +29,7 @@ int CharacterCommon::GetAnimationNumber(int currentAnimationCnt) {
 	return currentAnimationCnt / AppCommon::FRAME_COUNT_PER_CUT;
 }
 
-void CharacterCommon::CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<FloatPoint>& rChip, Rectangle<Drawing::DrawingVertex>* pRet) {
+void CharacterCommon::CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<Point<float>>& rChip, Rectangle<Drawing::DrawingVertex>* pRet) {
 	Rectangle<POINT> rect;
 	convertTopLeftToRect(rTopLeftPoint, &rect);
 

--- a/BestSteal_Replica/Character/CharacterCommon.h
+++ b/BestSteal_Replica/Character/CharacterCommon.h
@@ -1,8 +1,8 @@
 ﻿#ifndef CHARACTER_COMMON_H_
 #define CHARACTER_COMMON_H_
 
-#include "../AppCommon.h"
-#include "../Drawing/DrawingCommon.h"
+#include "AppCommon.h"
+#include "Drawing/DrawingCommon.h"
 
 
 namespace BestStealReplica {
@@ -15,11 +15,11 @@ public:
 	static const int WIDTH = 80;
 
 	/* Static Functions --------------------------------------------------------------------------------- */
-	static void CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<FloatPoint> pRetArr[]);
-	static void CreateTexRect(int rowIdx, int colIdx, Rectangle<FloatPoint>* pRet);
+	static void CreateTexRect(int chipCount, int rowIdx, int colIdx, Rectangle<Point<float>> pRetArr[]);
+	static void CreateTexRect(int rowIdx, int colIdx, Rectangle<Point<float>>* pRet);
 	static void CountUpAnimationCnt(int* pAnimationCnt, int chipCntPerDir);
 	static int GetAnimationNumber(int currentAnimationCnt);
-	static void CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<FloatPoint>& rChip, Rectangle<Drawing::DrawingVertex>* pRet);
+	static void CreateDrawingVertexRect(const POINT& rTopLeftPoint, void(*convertTopLeftToRect)(const POINT&, Rectangle<POINT>*), const Rectangle<Point<float>>& rChip, Rectangle<Drawing::DrawingVertex>* pRet);
 	static void ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet);
 	static void CalcCharacterRect(const POINT& rTopLeftPoint, int width, int height, Rectangle<POINT>* pRet);
 	static void CalcCenter(const Rectangle<POINT>& rRect, POINT* pRet);

--- a/BestSteal_Replica/Character/Enemy.cpp
+++ b/BestSteal_Replica/Character/Enemy.cpp
@@ -2,15 +2,15 @@
 #include <math.h>
 
 #include "Enemy.h"
-#include "../Drawing/Drawer.h"
-#include "../Map/MapChip.h"
+#include "Drawing/Drawer.h"
+#include "Map/MapChip.h"
 
 
 namespace BestStealReplica {
 namespace Character {
 
 /* Structs ------------------------------------------------------------------------------------------ */
-Enemy::EnemyInfo::EnemyInfo(int chipPosX, int chipPosY, AppCommon::Direction defaultDirection, AppCommon::GateKeyType holdingGateKey) :
+Enemy::EnemyInfo::EnemyInfo(UINT16 chipPosX, UINT16 chipPosY, AppCommon::Direction defaultDirection, AppCommon::GateKeyType holdingGateKey) :
 	defaultDirection(defaultDirection),
 	headingDirection(defaultDirection),
 	holdingGateKey(holdingGateKey),
@@ -25,7 +25,7 @@ Enemy::EnemyInfo::EnemyInfo(int chipPosX, int chipPosY, AppCommon::Direction def
 
 /* Constructor / Destructor ------------------------------------------------------------------------- */
 Enemy::Enemy(const std::vector<EnemyInfo>& rEnemiesInfo, const std::vector<POINT>& rTopLeftPoints, int scoutableRadius) : scoutableRadius(scoutableRadius) {	
-	for (int i = 0; i < (int)rEnemiesInfo.size(); ++i) {
+	for (UINT8 i = 0; i < rEnemiesInfo.size(); ++i) {
 		this->enemiesInfo.push_back(rEnemiesInfo[i]);
 		this->enemiesInfo.back().topLeftPoint = rTopLeftPoints[i];
 		this->enemiesInfo.back().defaultTopLeftPoint = rTopLeftPoints[i];
@@ -41,15 +41,15 @@ Enemy::Enemy(const std::vector<EnemyInfo>& rEnemiesInfo, const std::vector<POINT
 
 
 /* Getters / Setters -------------------------------------------------------------------------------- */
-int Enemy::GetEnermyCount() const {
-	return this->enemiesInfo.size();
+UINT8 Enemy::GetEnermyCount() const {
+	return (UINT8)this->enemiesInfo.size();
 }
 
-AppCommon::Direction Enemy::GetHeadingDirection(int enemyIdx) const {
+AppCommon::Direction Enemy::GetHeadingDirection(UINT8 enemyIdx) const {
 	return this->enemiesInfo[enemyIdx].headingDirection;
 }
 
-Enemy::State Enemy::GetState(int enemyIdx) const {
+Enemy::State Enemy::GetState(UINT8 enemyIdx) const {
 	return this->enemiesInfo[enemyIdx].state;
 }
 
@@ -61,7 +61,7 @@ void Enemy::ConfigureTextureTypes(std::vector<Drawing::TextureType>* pRet) const
 }
 
 void Enemy::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) const {
-	for (int enemyIdx = 0; enemyIdx < (int)this->enemiesInfo.size(); ++enemyIdx) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->enemiesInfo.size(); ++enemyIdx) {
 		Drawing::DrawingContext context;
 		context.textureType = Drawing::TextureType::CHARACTER;
 		CreateDrawingVertexRect(enemyIdx, &context.rect);
@@ -69,7 +69,7 @@ void Enemy::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) co
 		if (this->enemiesInfo[enemyIdx].state == State::GOT_STOLEN) {
 			// 点滅
 			double rad = this->enemiesInfo[enemyIdx].restTimeForBackingToNormal * 18 * M_PI / 180;
-			context.alpha = 0xFF * (UINT16)abs(sin(rad));
+			context.alpha = 0xffU * static_cast<UINT16>(abs(sin(rad)));
 
 			pRet->push_back(context);
 		} else {
@@ -92,10 +92,10 @@ void Enemy::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) co
 					exclTopLeft.x = enemyTopLeft.x + Map::MapChip::WIDTH;
 					exclTopLeft.y = enemyTopLeft.y;
 				}
-				Drawing::DrawingContext context;
-				context.textureType = Drawing::TextureType::MAP;
-				CharacterCommon::CreateDrawingVertexRect(exclTopLeft, &Map::MapChip::ConvertTopLeftPointToRect, this->texRectOfExclamationMarkChip, &context.rect);
-				pRet->push_back(context);
+				Drawing::DrawingContext exclContext;
+				exclContext.textureType = Drawing::TextureType::MAP;
+				CharacterCommon::CreateDrawingVertexRect(exclTopLeft, &Map::MapChip::ConvertTopLeftPointToRect, this->texRectOfExclamationMarkChip, &exclContext.rect);
+				pRet->push_back(exclContext);
 			}
 		}
 	}
@@ -114,18 +114,18 @@ void Enemy::Move(const POINT& rPixel) {
 	}
 }
 
-void Enemy::CalcEnemyRect(int enemyIdx, Rectangle<POINT>* pRet) const {
+void Enemy::CalcEnemyRect(UINT8 enemyIdx, Rectangle<POINT>* pRet) const {
 	CharacterCommon::CalcCharacterRect(this->enemiesInfo[enemyIdx].topLeftPoint, Enemy::ENEMY_WIDTH, Enemy::ENEMY_HEIGHT, pRet);
 }
 
-void Enemy::CalcCenter(int enemyIdx, POINT* pRet) const {
+void Enemy::CalcCenter(UINT8 enemyIdx, POINT* pRet) const {
 	Rectangle<POINT> enemyRect;
 	CalcEnemyRect(enemyIdx, &enemyRect);
 	CharacterCommon::CalcCenter(enemyRect, pRet);
 }
 
 void Enemy::ScoutStone(const std::vector<Rectangle<POINT>>& rStonesRect) {
-	for (int enemyIdx = 0; enemyIdx < (int)this->enemiesInfo.size(); ++enemyIdx) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->enemiesInfo.size(); ++enemyIdx) {
 		if (this->enemiesInfo[enemyIdx].state == Enemy::State::ATTACKING || this->enemiesInfo[enemyIdx].state == Enemy::State::GOT_STOLEN) {
 			return;
 		}
@@ -134,7 +134,7 @@ void Enemy::ScoutStone(const std::vector<Rectangle<POINT>>& rStonesRect) {
 		POINT enemyCenter;
 		CalcCenter(enemyIdx, &enemyCenter);
 
-		for (int stoneIdx = 0; stoneIdx < (int)rStonesRect.size(); ++stoneIdx) {
+		for (UINT8 stoneIdx = 0; stoneIdx < rStonesRect.size(); ++stoneIdx) {
 			POINT stoneCenter;
 			CharacterCommon::CalcCenter(rStonesRect[stoneIdx], &stoneCenter);
 			double distance = CharacterCommon::CalcDistance(enemyCenter, stoneCenter);
@@ -158,7 +158,7 @@ void Enemy::ScoutStone(const std::vector<Rectangle<POINT>>& rStonesRect) {
 }
 
 void Enemy::ScoutPlayer(const POINT& rPlayerCenter, bool isPlayerWalking) {
-	for (int enemyIdx = 0; enemyIdx < (int)this->enemiesInfo.size(); ++enemyIdx) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->enemiesInfo.size(); ++enemyIdx) {
 		POINT enemyCenter;
 		CalcCenter(enemyIdx, &enemyCenter);
 		double distance = CharacterCommon::CalcDistance(rPlayerCenter, enemyCenter);
@@ -196,7 +196,7 @@ void Enemy::ScoutPlayer(const POINT& rPlayerCenter, bool isPlayerWalking) {
 
 AppCommon::GateKeyType Enemy::GetStolen(const Rectangle<POINT>& rPlayerRect, bool isPlayerStealing) {
 	AppCommon::GateKeyType ret = AppCommon::GateKeyType::None;
-	for (int enemyIdx = 0; enemyIdx < (int)this->enemiesInfo.size(); ++enemyIdx) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->enemiesInfo.size(); ++enemyIdx) {
 		if (this->enemiesInfo[enemyIdx].state == State::GOT_STOLEN) {
 			--this->enemiesInfo[enemyIdx].restTimeForBackingToNormal;
 			if (this->enemiesInfo[enemyIdx].restTimeForBackingToNormal == 0) {
@@ -223,7 +223,7 @@ AppCommon::GateKeyType Enemy::GetStolen(const Rectangle<POINT>& rPlayerRect, boo
 	return ret;
 }
 
-void Enemy::Attack(int enemyIdx, bool canSeePlayer) {
+void Enemy::Attack(UINT8 enemyIdx, bool canSeePlayer) {
 	EnemyInfo* pEnemyInfo = &this->enemiesInfo[enemyIdx];
 	if (pEnemyInfo->state == Enemy::State::GOT_STOLEN) {
 		// 盗まれ中の場合は動かない
@@ -258,7 +258,7 @@ void Enemy::Attack(int enemyIdx, bool canSeePlayer) {
 
 bool Enemy::CanKillPlayer(const Rectangle<POINT>& rPlayerRect) const {
 	bool ret = false;
-	for (int enemyIdx = 0; enemyIdx < (int)this->enemiesInfo.size(); enemyIdx++) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->enemiesInfo.size(); enemyIdx++) {
 		if (this->enemiesInfo[enemyIdx].state == Enemy::State::GOT_STOLEN) {
 			continue;
 		}
@@ -284,8 +284,8 @@ void Enemy::BackToDefaultPosition() {
 
 
 /* Private Functions  ------------------------------------------------------------------------------- */
-void Enemy::CreateDrawingVertexRect(int enemyIdx, Rectangle<Drawing::DrawingVertex>* pRet) const {
-	Rectangle<FloatPoint> chip;
+void Enemy::CreateDrawingVertexRect(UINT8 enemyIdx, Rectangle<Drawing::DrawingVertex>* pRet) const {
+	Rectangle<Point<float>> chip;
 	int animationNum = CharacterCommon::GetAnimationNumber(this->enemiesInfo[enemyIdx].currentAnimationCnt);
 	switch (this->enemiesInfo[enemyIdx].headingDirection) {
 		case AppCommon::Direction::TOP:
@@ -305,7 +305,7 @@ void Enemy::CreateDrawingVertexRect(int enemyIdx, Rectangle<Drawing::DrawingVert
 	CharacterCommon::CreateDrawingVertexRect(this->enemiesInfo[enemyIdx].topLeftPoint, &CharacterCommon::ConvertTopLeftPointToRect, chip, pRet);
 }
 
-void Enemy::TurnTo(const POINT& rTargetPoint, int enemyIdx) {
+void Enemy::TurnTo(const POINT& rTargetPoint, UINT8 enemyIdx) {
 	POINT enemyCenter;
 	CalcCenter(enemyIdx, &enemyCenter);
 

--- a/BestSteal_Replica/Character/Enemy.h
+++ b/BestSteal_Replica/Character/Enemy.h
@@ -1,11 +1,8 @@
 ﻿#ifndef ENEMY_H_
 #define ENEMY_H_
 
-#include <vector>
-#include <windows.h>
-
-#include "../Character/CharacterCommon.h"
-#include "../Drawing/IDrawable.h" 
+#include "Character/CharacterCommon.h"
+#include "Drawing/IDrawable.h" 
 
 
 namespace BestStealReplica {
@@ -28,7 +25,7 @@ public:
 
 	/* Structs ------------------------------------------------------------------------------------------ */
 	struct EnemyInfo {
-		POINT chipPos;
+		Point<UINT16> chipPos;
 		POINT topLeftPoint;
 		POINT defaultTopLeftPoint;
 		AppCommon::Direction defaultDirection;
@@ -40,7 +37,7 @@ public:
 		int restTimeForBackingToNormal;
 
 		EnemyInfo() = default;
-		EnemyInfo(int chipPosX, int chipPosY, AppCommon::Direction defaultDirection, AppCommon::GateKeyType holdingGateKey);
+		EnemyInfo(UINT16 chipPosX, UINT16 chipPosY, AppCommon::Direction defaultDirection, AppCommon::GateKeyType holdingGateKey);
 		EnemyInfo(const EnemyInfo&) = default;
 	};
 
@@ -51,9 +48,9 @@ public:
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	int GetEnermyCount() const;
-	AppCommon::Direction GetHeadingDirection(int enemyIdx) const;
-	Enemy::State GetState(int enemyIdx) const;
+	UINT8 GetEnermyCount() const;
+	AppCommon::Direction GetHeadingDirection(UINT8 enemyIdx) const;
+	Enemy::State GetState(UINT8 enemyIdx) const;
 
 
 	/* Operator Overloads ------------------------------------------------------------------------------- */
@@ -66,12 +63,12 @@ public:
 
 	void Stay();
 	void Move(const POINT& rPixel);
-	void CalcEnemyRect(int enemyIdx, Rectangle<POINT>* pRet) const;
-	void CalcCenter(int enemyIdx, POINT* pRet) const;
+	void CalcEnemyRect(UINT8 enemyIdx, Rectangle<POINT>* pRet) const;
+	void CalcCenter(UINT8 enemyIdx, POINT* pRet) const;
 	void ScoutStone(const std::vector<Rectangle<POINT>>& rStonesRect);
 	void ScoutPlayer(const POINT& rPlayerCenter, bool isPlayerWalking);
 	AppCommon::GateKeyType GetStolen(const Rectangle<POINT>& rPlayerRect, bool isPlayerStealing);
-	void Attack(int enemyIdx, bool canSeePlayer);
+	void Attack(UINT8 enemyIdx, bool canSeePlayer);
 	bool CanKillPlayer(const Rectangle<POINT>& rPlayerRect) const;
 	void BackToDefaultPosition();
 
@@ -97,19 +94,19 @@ private:
 
 
 	/* Variables ---------------------------------------------------------------------------------------- */
-	Rectangle<FloatPoint> texRectOfHeadingBottomChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingTopChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingLeftChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingRightChips[Enemy::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfExclamationMarkChip;
+	Rectangle<Point<float>> texRectOfHeadingBottomChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingTopChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingLeftChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingRightChips[Enemy::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfExclamationMarkChip;
 
 	std::vector<EnemyInfo> enemiesInfo;
 	int scoutableRadius;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */
-	void CreateDrawingVertexRect(int enemyIdx, Rectangle<Drawing::DrawingVertex>* pRet) const;
-	void TurnTo(const POINT& rTargetPoint, int enemyIdx);
+	void CreateDrawingVertexRect(UINT8 enemyIdx, Rectangle<Drawing::DrawingVertex>* pRet) const;
+	void TurnTo(const POINT& rTargetPoint, UINT8 enemyIdx);
 
 };
 

--- a/BestSteal_Replica/Character/Player.cpp
+++ b/BestSteal_Replica/Character/Player.cpp
@@ -1,5 +1,5 @@
 ﻿#include "Player.h"
-#include "../Drawing/Drawer.h"
+#include "Drawing/Drawer.h"
 
 
 namespace BestStealReplica {
@@ -181,7 +181,7 @@ void Player::ReturnPropertiesToDefault() {
 }
 
 void Player::CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const {
-	Rectangle<FloatPoint> chip;
+	Rectangle<Point<float>> chip;
 	int animationNum = CharacterCommon::GetAnimationNumber(this->currentAnimationCnt);
 	switch (this->headingDirection) {
 		case AppCommon::Direction::TOP:
@@ -208,31 +208,31 @@ void Player::CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) co
  * @param [out] pRet 盗み処理中の頂点情報を格納して返却
  */
 void Player::CreateDrawingVertexRectOnStealing(int afterImageNum, Rectangle<Drawing::DrawingVertex>* pRet) const {
-	POINT topLeftPoint;
-	Rectangle<FloatPoint> chipTexRect;
+	POINT afterImageTopLeftPoint;
+	Rectangle<Point<float>> chipTexRect;
 	switch (this->headingDirection) {
 		case AppCommon::Direction::TOP:
-			topLeftPoint.x = this->topLeftPoint.x;
-			topLeftPoint.y = this->topLeftPoint.y + Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
+			afterImageTopLeftPoint.x = this->topLeftPoint.x;
+			afterImageTopLeftPoint.y = this->topLeftPoint.y + Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
 			chipTexRect = this->texRectOfStealingTopChip;
 			break;
 		case AppCommon::Direction::RIGHT:
-			topLeftPoint.x = this->topLeftPoint.x - Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
-			topLeftPoint.y = this->topLeftPoint.y;
+			afterImageTopLeftPoint.x = this->topLeftPoint.x - Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
+			afterImageTopLeftPoint.y = this->topLeftPoint.y;
 			chipTexRect = this->texRectOfStealingRightChip;
 			break;
 		case AppCommon::Direction::BOTTOM:
-			topLeftPoint.x = this->topLeftPoint.x;
-			topLeftPoint.y = this->topLeftPoint.y - Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
+			afterImageTopLeftPoint.x = this->topLeftPoint.x;
+			afterImageTopLeftPoint.y = this->topLeftPoint.y - Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
 			chipTexRect = this->texRectOfStealingBottomChip;
 			break;
 		case AppCommon::Direction::LEFT:
-			topLeftPoint.x = this->topLeftPoint.x + Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
-			topLeftPoint.y = this->topLeftPoint.y;
+			afterImageTopLeftPoint.x = this->topLeftPoint.x + Player::MOVING_PIXEL_ON_STEALING * afterImageNum;
+			afterImageTopLeftPoint.y = this->topLeftPoint.y;
 			chipTexRect = this->texRectOfStealingLeftChip;
 			break;
 	}
-	CharacterCommon::CreateDrawingVertexRect(topLeftPoint, &CharacterCommon::ConvertTopLeftPointToRect, chipTexRect, pRet);
+	CharacterCommon::CreateDrawingVertexRect(afterImageTopLeftPoint, &CharacterCommon::ConvertTopLeftPointToRect, chipTexRect, pRet);
 }
 
 const int* Player::GetHoldingGateKeyCnt(AppCommon::GateKeyType gateKey) const {

--- a/BestSteal_Replica/Character/Player.h
+++ b/BestSteal_Replica/Character/Player.h
@@ -1,10 +1,8 @@
 ﻿#ifndef PLAYER_H_
 #define PLAYER_H_
 
-#include <windows.h>
-
-#include "../Character/CharacterCommon.h"
-#include "../Drawing/IDrawable.h"
+#include "Character/CharacterCommon.h"
+#include "Drawing/IDrawable.h"
 
 
 namespace BestStealReplica {
@@ -92,14 +90,14 @@ private:
 	int holdingGoldGateKeyCount;
 	int holdingSilverGateKeyCount;
 
-	Rectangle<FloatPoint> texRectOfHeadingBottomChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingTopChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingLeftChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfHeadingRightChips[Player::CHIP_COUNT_PER_DIRECTION];
-	Rectangle<FloatPoint> texRectOfStealingBottomChip;
-	Rectangle<FloatPoint> texRectOfStealingTopChip;
-	Rectangle<FloatPoint> texRectOfStealingLeftChip;
-	Rectangle<FloatPoint> texRectOfStealingRightChip;
+	Rectangle<Point<float>> texRectOfHeadingBottomChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingTopChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingLeftChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfHeadingRightChips[Player::CHIP_COUNT_PER_DIRECTION];
+	Rectangle<Point<float>> texRectOfStealingBottomChip;
+	Rectangle<Point<float>> texRectOfStealingTopChip;
+	Rectangle<Point<float>> texRectOfStealingLeftChip;
+	Rectangle<Point<float>> texRectOfStealingRightChip;
 
 
 	/* Functions ---------------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/Drawing/Drawer.cpp
+++ b/BestSteal_Replica/Drawing/Drawer.cpp
@@ -3,7 +3,7 @@
 #include <d3dx9tex.h>
 
 #include "Drawer.h"
-#include "../Drawing/IDRawable.h"
+#include "Drawing/IDRawable.h"
 
 
 #define D3DFVF_CUSTOMVERTEX (D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1)
@@ -83,7 +83,7 @@ void Drawer::Draw() {
 	// 描画データ生成
 	DataTable<DrawingContext> contextTable;
 	contextTable.resize(pDrawables.size());
-	for (int i = 0; i < (int)pDrawables.size(); ++i) {
+	for (UINT16 i = 0; i < pDrawables.size(); ++i) {
 		pDrawables[i]->CreateDrawingContexts(&contextTable[i]);
 	}
 

--- a/BestSteal_Replica/Drawing/Drawer.h
+++ b/BestSteal_Replica/Drawing/Drawer.h
@@ -1,13 +1,11 @@
 ﻿#ifndef DRAWER_H_
 #define DRAWER_H_
 
-#include <vector>
-#include <map>
 #include <d3d9.h>
 #include <d3dx9.h>
 
-#include "../AppCommon.h"
-#include "../Drawing/DrawingCommon.h"
+#include "AppCommon.h"
+#include "Drawing/DrawingCommon.h"
 
 
 namespace BestStealReplica {

--- a/BestSteal_Replica/Drawing/DrawingCommon.h
+++ b/BestSteal_Replica/Drawing/DrawingCommon.h
@@ -1,23 +1,23 @@
 ﻿#ifndef DRAWING_COMMON_H_
 #define DRAWING_COMMON_H_
 
-#include "../AppCommon.h"
+#include "AppCommon.h"
 
 
 namespace BestStealReplica {
 namespace Drawing {
 
 /* Structs ------------------------------------------------------------------------------------------ */
+/**
+ * 描画情報を持つ構造体
+ *
+ * 当構造体はコピー可能とする。
+ */
 struct DrawingVertex {
 	int x;
 	int y;
 	float tu;
 	float tv;
-
-	DrawingVertex() = default;
-	DrawingVertex(const DrawingVertex&) = default;
-
-	DrawingVertex& operator=(const DrawingVertex&) = delete;
 };
 
 /* Enums -------------------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/Drawing/IDrawable.h
+++ b/BestSteal_Replica/Drawing/IDrawable.h
@@ -1,10 +1,8 @@
 ﻿#ifndef IDRAWABLE_H_
 #define IDRAWABLE_H_
 
-#include <vector>
-
-#include "../AppCommon.h"
-#include "../Drawing/DrawingCommon.h"
+#include "AppCommon.h"
+#include "Drawing/DrawingCommon.h"
 
 
 namespace BestStealReplica {
@@ -15,6 +13,7 @@ public:
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
 	IDrawable() = default;
 	IDrawable(const IDrawable&) = delete;
+	virtual ~IDrawable() = default;
 
 	/* Operator Overloads ------------------------------------------------------------------------------- */
 	IDrawable& operator=(const IDrawable&) = delete;

--- a/BestSteal_Replica/Main.cpp
+++ b/BestSteal_Replica/Main.cpp
@@ -1,5 +1,4 @@
-﻿#include <windows.h>
-#include <mmsystem.h >
+﻿#include <mmsystem.h>
 #include <d3d9.h>
 
 #define DIRECTINPUT_VERSION 0x0800
@@ -26,7 +25,7 @@ static void WINAPI DI_Term();
 }
 
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, int nCmdShow) {
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, PSTR /*lpCmdLine*/, int /*nCmdShow*/) {
 	using namespace BestStealReplica;
 
 	::_CrtSetDbgFlag(_CRTDBG_LEAK_CHECK_DF | _CRTDBG_ALLOC_MEM_DF);

--- a/BestSteal_Replica/Map/Map.cpp
+++ b/BestSteal_Replica/Map/Map.cpp
@@ -1,14 +1,14 @@
-﻿#include <algorithm>
+﻿#include <stdint.h>
 
 #include "Map.h"
-#include "../AppCommon.h"
-#include "../Map/MapChip.h"
-#include "../Map/MapChipWall.h"
-#include "../Map/MapChipGate.h"
-#include "../Map/MapChipJewelry.h"
-#include "../Drawing/Drawer.h"
-#include "../Stage/IStage.h"
-#include "../Map/Stone.h"
+#include "AppCommon.h"
+#include "Map/MapChip.h"
+#include "Map/MapChipWall.h"
+#include "Map/MapChipGate.h"
+#include "Map/MapChipJewelry.h"
+#include "Drawing/Drawer.h"
+#include "Stage/IStage.h"
+#include "Map/Stone.h"
 
 
 namespace BestStealReplica {
@@ -34,7 +34,7 @@ Map::~Map() {
 
 
 /* Getters / Setters -------------------------------------------------------------------------------- */
-MapChipType Map::GetMapChipType(const POINT& rMapChipPos) const {
+MapChipType Map::GetMapChipType(const Point<UINT16>& rMapChipPos) const {
 	return this->pMapData[rMapChipPos.y][rMapChipPos.x]->GetChipType();
 }
 
@@ -60,14 +60,14 @@ void Map::CreateDrawingContexts(std::vector<Drawing::DrawingContext>* pRet) cons
 }
 
 void Map::Load(const Stage::IStage& rStage) {
-	int yChipCount = rStage.GetYChipCount();
-	int xChipCount = rStage.GetXChipCount();
+	UINT16 yChipCount = rStage.GetYChipCount();
+	UINT16 xChipCount = rStage.GetXChipCount();
 
 	this->pMapData.resize(yChipCount);
-	for (int rowIdx = 0; rowIdx < yChipCount; ++rowIdx) {
+	for (UINT16 rowIdx = 0; rowIdx < yChipCount; ++rowIdx) {
 		this->pMapData[rowIdx].resize(xChipCount);
 
-		for (int colIdx = 0; colIdx < xChipCount; ++colIdx) {			
+		for (UINT16 colIdx = 0; colIdx < xChipCount; ++colIdx) {			
 			this->pMapData[rowIdx][colIdx] = MapChip::Create(rStage.GetMapChipType(rowIdx, colIdx));
 
 			switch (this->pMapData[rowIdx][colIdx]->GetChipType()) {
@@ -85,7 +85,7 @@ void Map::Load(const Stage::IStage& rStage) {
 	}
 
 	// プレイヤーが画面中央になる場合の座標を計算
-	POINT playerChipPos;
+	Point<UINT16> playerChipPos;
 	rStage.GetPlayerFirstChipPos(&playerChipPos);
 	POINT center;
 	center.x = AppCommon::GetWindowWidth() / 2;
@@ -141,28 +141,28 @@ bool Map::IsMovableY(int pixel) const {
 
 bool Map::IsOnRoad(const Rectangle<POINT>& rRect) const {
 	// 4頂点のチップ位置を取得
-	POINT topLeftChipPos;
+	Point<UINT16> topLeftChipPos;
 	ConvertToMapChipPos(rRect.topLeft, &topLeftChipPos);
 
 	POINT topRightPoint;
 	topRightPoint.x = rRect.bottomRight.x;
 	topRightPoint.y = rRect.topLeft.y;
-	POINT topRightChipPos;
+	Point<UINT16> topRightChipPos;
 	ConvertToMapChipPos(topRightPoint, &topRightChipPos);
 
-	POINT bottomRightChipPos;
+	Point<UINT16> bottomRightChipPos;
 	ConvertToMapChipPos(rRect.bottomRight, &bottomRightChipPos);
 
 	POINT bottomLeftPoint;
 	bottomLeftPoint.x = rRect.topLeft.x;
 	bottomLeftPoint.y = rRect.bottomRight.y;
-	POINT bottomLeftChipPos;
+	Point<UINT16> bottomLeftChipPos;
 	ConvertToMapChipPos(bottomLeftPoint, &bottomLeftChipPos);
 
 	return IsOnRoad(topLeftChipPos) && IsOnRoad(topRightChipPos) && IsOnRoad(bottomRightChipPos) && IsOnRoad(bottomLeftChipPos);
 }
 
-void Map::ConvertMapChipPosToTopLeftPoint(const POINT& rMapChipPos, POINT* pRet) const {
+void Map::ConvertMapChipPosToTopLeftPoint(const Point<UINT16>& rMapChipPos, POINT* pRet) const {
 	this->pMapData[rMapChipPos.y][rMapChipPos.x]->GetTopLeftPoint(pRet);
 }
 
@@ -187,7 +187,7 @@ void Map::KeepOpeningGates() {
  * @param[in] headingDirection キャラクターの向き
  * @param[out] pRet キャラクターの目の前のマップチップの行列番号を格納して返却
  */
-void Map::ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRect, AppCommon::Direction headingDirection, POINT* pRet) const {
+void Map::ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRect, AppCommon::Direction headingDirection, Point<UINT16>* pRet) const {
 	POINT characterCenter;
 	characterCenter.x = (rCharacterRect.bottomRight.x + rCharacterRect.topLeft.x) / 2;
 	characterCenter.y = (rCharacterRect.bottomRight.y + rCharacterRect.topLeft.y) / 2;
@@ -217,7 +217,7 @@ void Map::ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRe
 	}
 }
 
-bool Map::StartOpeningGate(const POINT& rMapChipPos) {
+bool Map::StartOpeningGate(const Point<UINT16>& rMapChipPos) {
 	bool ret = false;
 	switch (this->pMapData[rMapChipPos.y][rMapChipPos.x]->GetChipType()) {
 		case MapChipType::GATE:
@@ -240,7 +240,7 @@ bool Map::StartOpeningGate(const POINT& rMapChipPos) {
 	return ret;
 }
 
-bool Map::IsGateOpened(const POINT& rMapChipPos) const {
+bool Map::IsGateOpened(const Point<UINT16>& rMapChipPos) const {
 	bool ret = false;
 	MapChip& rChip = *(this->pMapData[rMapChipPos.y][rMapChipPos.x]);
 	switch (rChip.GetChipType()) {
@@ -256,16 +256,16 @@ bool Map::IsGateOpened(const POINT& rMapChipPos) const {
 
 bool Map::ExistsWallBetween(const POINT& rPoint1, const POINT& rPoint2) const {
 	bool ret = false;
-	POINT pos1;
+	Point<UINT16> pos1;
 	ConvertToMapChipPos(rPoint1, &pos1);
-	POINT pos2;
+	Point<UINT16> pos2;
 	ConvertToMapChipPos(rPoint2, &pos2);
 
 	if (pos1.x != pos2.x && pos1.y != pos2.y) {
 		return true;
 	}
 
-	POINT checkPos = pos1;
+	Point<UINT16> checkPos = pos1;
 	while (pos1.x == pos2.x ? checkPos.y != pos2.y : checkPos.x != pos2.x) {
 		switch (this->pMapData[checkPos.y][checkPos.x]->GetChipType()) {
 			case MapChipType::WALL:
@@ -307,17 +307,17 @@ void Map::OpenJewelryBox() {
 	this->pJewelryMapChip->OpenBox();
 }
 
-void Map::ConvertToMapChipPos(const POINT& rPoint, POINT* pRet) const {
+void Map::ConvertToMapChipPos(const POINT& rPoint, Point<UINT16>* pRet) const {
 	if (rPoint.x < this->topLeftPoint.x) {
-		pRet->x = -1;
+		pRet->x = UINT16_MAX;
 	} else {
-		pRet->x = (rPoint.x - this->topLeftPoint.x) / MapChip::WIDTH;
+		pRet->x = static_cast<UINT16>((rPoint.x - this->topLeftPoint.x) / MapChip::WIDTH);
 	}
 
 	if (rPoint.y < this->topLeftPoint.y) {
-		pRet->y = -1;
+		pRet->y = UINT16_MAX;
 	} else {
-		pRet->y = (rPoint.y - this->topLeftPoint.y) / MapChip::HEIGHT;
+		pRet->y = static_cast<UINT16>((rPoint.y - this->topLeftPoint.y) / MapChip::HEIGHT);
 	}
 }
 
@@ -326,7 +326,7 @@ void Map::AddStone(const POINT& rTopLeftPoint, AppCommon::Direction direction) {
 }
 
 void Map::AnimateStones() {
-	for (int i = 0; i < (int)this->pStones.size(); ++i) {
+	for (UINT8 i = 0; i < this->pStones.size(); ++i) {
 		this->pStones[i]->KeepBeingThrown();
 		
 		if (this->pStones[i]->Exists()) {
@@ -369,8 +369,8 @@ void Map::CalcDroppedStonesRect(std::vector<Rectangle<POINT>>* pRet) const {
 
 /* Private Functions  ------------------------------------------------------------------------------- */
 void Map::AssignChipNumber() {
-	for (int rowIdx = 0; rowIdx < (int)this->pMapData.size(); ++rowIdx) {
-		for (int colIdx = 0; colIdx < (int)this->pMapData[rowIdx].size(); ++colIdx) {
+	for (UINT16 rowIdx = 0; rowIdx < this->pMapData.size(); ++rowIdx) {
+		for (UINT16 colIdx = 0; colIdx < this->pMapData[rowIdx].size(); ++colIdx) {
 
 			if (this->pMapData[rowIdx][colIdx]->GetChipType() == MapChipType::WALL) {
 				MapChipWall* chip = (MapChipWall*)this->pMapData[rowIdx][colIdx];
@@ -378,7 +378,7 @@ void Map::AssignChipNumber() {
 				if (rowIdx == 0) {
 					chip->SetNeedsTopLine();
 				} else {
-					if (this->pMapData[rowIdx - 1][colIdx]->GetChipType() != MapChipType::WALL) {
+					if (this->pMapData[rowIdx - 1U][colIdx]->GetChipType() != MapChipType::WALL) {
 						chip->SetNeedsTopLine();
 					}
 				}
@@ -386,23 +386,23 @@ void Map::AssignChipNumber() {
 				if (colIdx == 0) {
 					chip->SetNeedsLeftLine();
 				} else {
-					if (this->pMapData[rowIdx][colIdx - 1]->GetChipType() != MapChipType::WALL) {
+					if (this->pMapData[rowIdx][colIdx - 1U]->GetChipType() != MapChipType::WALL) {
 						chip->SetNeedsLeftLine();
 					}
 				}
 
-				if (rowIdx == this->pMapData.size() - 1) {
+				if (rowIdx == this->pMapData.size() - 1U) {
 					chip->SetNeedsBottomLine();
 				} else {
-					if (this->pMapData[rowIdx + 1][colIdx]->GetChipType() != MapChipType::WALL) {
+					if (this->pMapData[rowIdx + 1U][colIdx]->GetChipType() != MapChipType::WALL) {
 						chip->SetNeedsBottomLine();
 					}
 				}
 
-				if (colIdx == this->pMapData[rowIdx].size() - 1) {
+				if (colIdx == this->pMapData[rowIdx].size() - 1U) {
 					chip->SetNeedsRightLine();
 				} else {
-					if (this->pMapData[rowIdx][colIdx + 1]->GetChipType() != MapChipType::WALL) {
+					if (this->pMapData[rowIdx][colIdx + 1U]->GetChipType() != MapChipType::WALL) {
 						chip->SetNeedsRightLine();
 					}
 				}
@@ -415,8 +415,8 @@ void Map::AssignChipNumber() {
 
 void Map::ConfigureChipPoint() {
 	POINT point;
-	for (int rowIdx = 0; rowIdx < (int)this->pMapData.size(); ++rowIdx) {
-		for (int colIdx = 0; colIdx < (int)this->pMapData[rowIdx].size(); ++colIdx) {
+	for (UINT16 rowIdx = 0; rowIdx < this->pMapData.size(); ++rowIdx) {
+		for (UINT16 colIdx = 0; colIdx < this->pMapData[rowIdx].size(); ++colIdx) {
 			point.x = this->topLeftPoint.x + (colIdx * MapChip::WIDTH);
 			point.y = this->topLeftPoint.y + (rowIdx * MapChip::HEIGHT);
 			this->pMapData[rowIdx][colIdx]->SetTopLeftPoint(point);
@@ -424,8 +424,8 @@ void Map::ConfigureChipPoint() {
 	}
 }
 
-bool Map::IsOnRoad(const POINT& rMapChipPos) const {
-	if (rMapChipPos.x < 0 || rMapChipPos.x >= (int)this->pMapData[0].size() || rMapChipPos.y < 0 || rMapChipPos.y >= (int)this->pMapData.size()) {
+bool Map::IsOnRoad(const Point<UINT16>& rMapChipPos) const {
+	if (rMapChipPos.x == UINT16_MAX || rMapChipPos.x >= (int)this->pMapData[0].size() || rMapChipPos.y == UINT16_MAX || rMapChipPos.y >= (int)this->pMapData.size()) {
 		return false;
 	}
 	switch (this->pMapData[rMapChipPos.y][rMapChipPos.x]->GetChipType()) {
@@ -439,20 +439,22 @@ bool Map::IsOnRoad(const POINT& rMapChipPos) const {
 				return false;
 			}
 			break;
+		default:
+			break;
 	}
 	return true;
 }
 
-bool Map::IsMovable(int targetPoint, int topLeftPoint, int mapChipCount, int mapChipSize, int windowSize) const {
-	if (targetPoint == 0) {
+bool Map::IsMovable(int argTargetPoint, int argTopLeftPoint, int argMapChipCount, int argMapChipSize, int argWindowSize) const {
+	if (argTargetPoint == 0) {
 		return true;
 	}
-	if (targetPoint > 0) {
-		if (topLeftPoint + targetPoint > 0) {
+	if (argTargetPoint > 0) {
+		if (argTopLeftPoint + argTargetPoint > 0) {
 			return false;
 		}
-	} else if (targetPoint < 0) {
-		if (topLeftPoint + mapChipCount * mapChipSize <= windowSize) {
+	} else if (argTargetPoint < 0) {
+		if (argTopLeftPoint + argMapChipCount * argMapChipSize <= argWindowSize) {
 			return false;
 		}
 	}

--- a/BestSteal_Replica/Map/Map.h
+++ b/BestSteal_Replica/Map/Map.h
@@ -1,12 +1,9 @@
 ﻿#ifndef MAP_H_
 #define MAP_H_
 
-#include <windows.h>
-#include <vector>
-
-#include "../AppCommon.h"
-#include "../Map/MapCommon.h"
-#include "../Drawing/IDrawable.h"
+#include "AppCommon.h"
+#include "Map/MapCommon.h"
+#include "Drawing/IDrawable.h"
 
 
 namespace BestStealReplica {
@@ -31,7 +28,7 @@ public:
 
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	MapChipType GetMapChipType(const POINT& rMapChipPos) const;
+	MapChipType GetMapChipType(const Point<UINT16>& rMapChipPos) const;
 
 
 	/* Operator Overloads ------------------------------------------------------------------------------- */
@@ -48,14 +45,14 @@ public:
 	bool IsMovableX(int x) const;
 	bool IsMovableY(int y) const;
 	bool IsOnRoad(const Rectangle<POINT>& rRect) const;
-	void ConvertMapChipPosToTopLeftPoint(const POINT& rCharacterRect, POINT* pRet) const;
+	void ConvertMapChipPosToTopLeftPoint(const Point<UINT16>& rMapChipPos, POINT* pRet) const;
 	void KeepOpeningGates();
-	void ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRect, AppCommon::Direction headingDirection, POINT* pRet) const;
-	bool StartOpeningGate(const POINT& rMapChipPos);
-	bool IsGateOpened(const POINT& rMapChipPos) const;
+	void ConvertToCharacterFrontMapChipPos(const Rectangle<POINT>& rCharacterRect, AppCommon::Direction headingDirection, Point<UINT16>* pRet) const;
+	bool StartOpeningGate(const Point<UINT16>& rMapChipPos);
+	bool IsGateOpened(const Point<UINT16>& rMapChipPos) const;
 	bool ExistsWallBetween(const POINT& rPoint1, const POINT& rPoint2) const;
 	void OpenJewelryBox();
-	void ConvertToMapChipPos(const POINT& rPoint, POINT* pRet) const;
+	void ConvertToMapChipPos(const POINT& rPoint, Point<UINT16>* pRet) const;
 	void AddStone(const POINT& rTopLeftPoint, AppCommon::Direction direction);
 	void AnimateStones();
 	void CalcDroppedStonesRect(std::vector<Rectangle<POINT>>* pRet) const;
@@ -78,7 +75,7 @@ private:
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void AssignChipNumber();
 	void ConfigureChipPoint();
-	bool IsOnRoad(const POINT& rMapChipPos) const;
+	bool IsOnRoad(const Point<UINT16>& rMapChipPos) const;
 	bool IsMovable(int targetPoint, int topLeftPoint, int mapChipCount, int mapChipSize, int windowSize) const;
 
 };

--- a/BestSteal_Replica/Map/MapChip.cpp
+++ b/BestSteal_Replica/Map/MapChip.cpp
@@ -1,7 +1,7 @@
 ﻿#include "MapChip.h"
-#include "../Map/MapChipWall.h"
-#include "../Map/MapChipGate.h"
-#include "../Map/MapChipJewelry.h"
+#include "Map/MapChipWall.h"
+#include "Map/MapChipGate.h"
+#include "Map/MapChipJewelry.h"
 
 
 namespace BestStealReplica {
@@ -25,7 +25,7 @@ MapChip* MapChip::Create(MapChipType chipType) {
 	}
 }
 
-void MapChip::ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<FloatPoint>* pRet) {
+void MapChip::ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<Point<float>>* pRet) {
 	int chipPosX = mapChipNumber % CHIP_COUNT_PER_ROW;
 	int chipPosY = mapChipNumber / CHIP_COUNT_PER_ROW;
 
@@ -88,7 +88,7 @@ MapChip::MapChip(MapChipType chipType) : chipType(chipType) {}
 
 /* Private Functions -------------------------------------------------------------------------------- */
 void MapChip::ConfigureTexRect() {
-	Rectangle<FloatPoint> texRect;
+	Rectangle<Point<float>> texRect;
 	ConvertChipNumberToTexRect(this->chipNumber, &texRect);
 	this->drawingVertexRect.topLeft.tu = texRect.topLeft.x;
 	this->drawingVertexRect.topLeft.tv = texRect.topLeft.y;

--- a/BestSteal_Replica/Map/MapChip.h
+++ b/BestSteal_Replica/Map/MapChip.h
@@ -1,11 +1,9 @@
 ﻿#ifndef MAP_CHIP_H_
 #define MAP_CHIP_H_
 
-#include <windows.h>
-
-#include "../AppCommon.h"
-#include "../Map/MapCommon.h"
-#include "../Drawing/DrawingCommon.h"
+#include "AppCommon.h"
+#include "Map/MapCommon.h"
+#include "Drawing/DrawingCommon.h"
 
 
 namespace BestStealReplica {
@@ -21,7 +19,7 @@ public:
 
 	/* Static Functions --------------------------------------------------------------------------------- */
 	static MapChip* Create(MapChipType chipType);
-	static void ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<FloatPoint>* pRet);
+	static void ConvertChipNumberToTexRect(int mapChipNumber, Rectangle<Point<float>>* pRet);
 	static void ConvertTopLeftPointToRect(const POINT& rTopLeftPoint, Rectangle<POINT>* pRet);
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */

--- a/BestSteal_Replica/Map/MapChipGate.h
+++ b/BestSteal_Replica/Map/MapChipGate.h
@@ -1,9 +1,7 @@
 ﻿#ifndef MAP_CHIP_GATE_H_
 #define MAP_CHIP_GATE_H_
 
-#include <windows.h>
-
-#include "../Map/MapChip.h"
+#include "Map/MapChip.h"
 
 
 namespace BestStealReplica {

--- a/BestSteal_Replica/Map/MapChipJewelry.h
+++ b/BestSteal_Replica/Map/MapChipJewelry.h
@@ -1,9 +1,7 @@
 ﻿#ifndef MAP_CHIP_JEWELRY_H_
 #define MAP_CHIP_JEWELRY_H_
 
-#include <windows.h>
-
-#include "../Map/MapChip.h"
+#include "Map/MapChip.h"
 
 
 namespace BestStealReplica {

--- a/BestSteal_Replica/Map/MapChipWall.h
+++ b/BestSteal_Replica/Map/MapChipWall.h
@@ -1,9 +1,7 @@
 ﻿#ifndef MAP_CHIP_WALL_H_
 #define MAP_CHIP_WALL_H_
 
-#include <windows.h>
-
-#include "../Map/MapChip.h"
+#include "Map/MapChip.h"
 
 
 namespace BestStealReplica {

--- a/BestSteal_Replica/Map/Stone.cpp
+++ b/BestSteal_Replica/Map/Stone.cpp
@@ -1,8 +1,8 @@
 ﻿#include <math.h>
 
 #include "Stone.h"
-#include "../Drawing/Drawer.h"
-#include "../Map/MapChip.h"
+#include "Drawing/Drawer.h"
+#include "Map/MapChip.h"
 
 
 namespace BestStealReplica {
@@ -79,8 +79,6 @@ void Stone::KeepBeingThrown() {
 				this->topLeftPoint = this->defaultTopLeftPoint;
 				this->topLeftPointOnGnd = this->defaultTopLeftPoint;
 			} else {
-				int velocity = Stone::INITIAL_VELOCITY;
-				int g = Stone::GRAVITY;
 				int distance = Stone::INITIAL_VELOCITY * this->thrownElapsedCount;
 				int height = Stone::INITIAL_VELOCITY * this->thrownElapsedCount - (Stone::GRAVITY * (int)pow(double(this->thrownElapsedCount), 2) / 2);
 
@@ -135,6 +133,8 @@ void Stone::KeepBeingThrown() {
 				this->state = Stone::State::DiSAPPEARED;
 			}
 			break;
+		default:
+			break;
 	}
 }
 
@@ -181,7 +181,7 @@ void Stone::BackOnePixel() {
 /* Private Functions  ------------------------------------------------------------------------------- */
 void Stone::CreateDrawingVertexRect(Rectangle<Drawing::DrawingVertex>* pRet) const {
 	Drawing::DrawingVertex* pRetArr[] = { &pRet->topLeft, &pRet->bottomRight };
-	const FloatPoint* pTexPointArr[] = { &this->texRect.topLeft, &this->texRect.bottomRight };
+	const Point<float>* pTexPointArr[] = { &this->texRect.topLeft, &this->texRect.bottomRight };
 
 	POINT bottomRightPoint;
 	bottomRightPoint.x = this->topLeftPoint.x + Stone::WIDTH;

--- a/BestSteal_Replica/Map/Stone.h
+++ b/BestSteal_Replica/Map/Stone.h
@@ -1,10 +1,8 @@
 ﻿#ifndef STONE_H_
 #define STONE_H_
 
-#include <windows.h>
-
-#include "../AppCommon.h"
-#include "../Drawing/DrawingCommon.h"
+#include "AppCommon.h"
+#include "Drawing/DrawingCommon.h"
 
 
 namespace BestStealReplica {
@@ -57,7 +55,7 @@ private:
 	POINT defaultTopLeftPoint;
 	POINT topLeftPoint;
 	AppCommon::Direction direction;
-	Rectangle<FloatPoint> texRect;
+	Rectangle<Point<float>> texRect;
 	int thrownElapsedCount;
 	Stone::State state;
 	int restTime;

--- a/BestSteal_Replica/SceneController.h
+++ b/BestSteal_Replica/SceneController.h
@@ -3,6 +3,7 @@
 
 #include "AppCommon.h"
 
+
 //LPDIRECTINPUTDEVICE8;
 typedef struct IDirectInputDevice8 *LPDIRECTINPUTDEVICE8;
 

--- a/BestSteal_Replica/Stage/IStage.h
+++ b/BestSteal_Replica/Stage/IStage.h
@@ -1,11 +1,8 @@
 ﻿#ifndef ISTAGE_H_
 #define ISTAGE_H_
 
-#include <vector>
-#include <windows.h>
-
-#include "../Map/MapCommon.h"
-#include "../Character/Enemy.h"
+#include "Map/MapCommon.h"
+#include "Character/Enemy.h"
 
 
 namespace BestStealReplica {
@@ -16,18 +13,19 @@ public:
 	/* Constructor / Destructor ------------------------------------------------------------------------- */
 	IStage() = default;
 	IStage(const IStage&) = delete;
+	virtual ~IStage() = default;
 
 	/* Operator Overloads ------------------------------------------------------------------------------- */
 	IStage& operator=(const IStage&) = delete;
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	virtual int GetYChipCount() const = 0;
-	virtual int GetXChipCount() const = 0;
-	virtual Map::MapChipType GetMapChipType(int y, int x) const = 0;
-	virtual void GetPlayerFirstChipPos(POINT* pRet) const = 0;
+	virtual UINT16 GetYChipCount() const = 0;
+	virtual UINT16 GetXChipCount() const = 0;
+	virtual Map::MapChipType GetMapChipType(UINT16 y, UINT16 x) const = 0;
+	virtual void GetPlayerFirstChipPos(Point<UINT16>* pRet) const = 0;
 	virtual void GetEnemiesInfo(std::vector<Character::Enemy::EnemyInfo>* pRet) const = 0;
 	virtual int GetEnemyScoutableRadius() const = 0;
-	virtual int GetMaxStoneCount() const = 0;
+	virtual UINT8 GetMaxStoneCount() const = 0;
 
 };
 

--- a/BestSteal_Replica/Stage/Stage1.cpp
+++ b/BestSteal_Replica/Stage/Stage1.cpp
@@ -1,6 +1,6 @@
 ﻿#include "Stage1.h"
-#include "../AppCommon.h"
-#include "../Character/Enemy.h"
+#include "AppCommon.h"
+#include "Character/Enemy.h"
 
 
 namespace BestStealReplica {
@@ -35,31 +35,31 @@ DataTable<Map::MapChipType> mapChipTypes = {
 };
 
 std::vector<Enemy::EnemyInfo> enemiesInfo = {
-	Enemy::EnemyInfo(6, 4, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::None),
-	Enemy::EnemyInfo(24, 0, AppCommon::Direction::LEFT, AppCommon::GateKeyType::Silver),
-	Enemy::EnemyInfo(1, 20, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Silver),
-	Enemy::EnemyInfo(22, 7, AppCommon::Direction::LEFT, AppCommon::GateKeyType::None),
-	Enemy::EnemyInfo(3, 16, AppCommon::Direction::BOTTOM, AppCommon::GateKeyType::Silver),
-	Enemy::EnemyInfo(9, 20, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Silver),
-	Enemy::EnemyInfo(21, 14, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Gold)
+	Enemy::EnemyInfo(6U, 4U, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::None),
+	Enemy::EnemyInfo(24U, 0U, AppCommon::Direction::LEFT, AppCommon::GateKeyType::Silver),
+	Enemy::EnemyInfo(1U, 20U, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Silver),
+	Enemy::EnemyInfo(22U, 7U, AppCommon::Direction::LEFT, AppCommon::GateKeyType::None),
+	Enemy::EnemyInfo(3U, 16U, AppCommon::Direction::BOTTOM, AppCommon::GateKeyType::Silver),
+	Enemy::EnemyInfo(9U, 20U, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Silver),
+	Enemy::EnemyInfo(21U, 14U, AppCommon::Direction::RIGHT, AppCommon::GateKeyType::Gold)
 };
 
 }
 
 /* Getters / Setters -------------------------------------------------------------------------------- */
-int Stage1::GetYChipCount() const {
-	return mapChipTypes.size();
+UINT16 Stage1::GetYChipCount() const {
+	return (UINT16)mapChipTypes.size();
 }
 
-int Stage1::GetXChipCount() const {
-	return mapChipTypes[0].size();
+UINT16 Stage1::GetXChipCount() const {
+	return (UINT16)mapChipTypes[0].size();
 }
 
-Map::MapChipType Stage1::GetMapChipType(int y, int x) const {
+Map::MapChipType Stage1::GetMapChipType(UINT16 y, UINT16 x) const {
 	return mapChipTypes[y][x];
 }
 
-void Stage1::GetPlayerFirstChipPos(POINT* pRet) const {
+void Stage1::GetPlayerFirstChipPos(Point<UINT16>* pRet) const {
 	pRet->x = 14;
 	pRet->y = 20;
 }
@@ -74,7 +74,7 @@ int Stage1::GetEnemyScoutableRadius() const {
 	return 260;
 }
 
-int Stage1::GetMaxStoneCount() const {
+UINT8 Stage1::GetMaxStoneCount() const {
 	return MAX_STONE_COUNT;
 }
 

--- a/BestSteal_Replica/Stage/Stage1.h
+++ b/BestSteal_Replica/Stage/Stage1.h
@@ -1,7 +1,7 @@
 ﻿#ifndef STAGE1_H_
 #define STAGE1_H_
 
-#include "../Stage/IStage.h"
+#include "IStage.h"
 
 namespace BestStealReplica {
 namespace Stage {
@@ -14,20 +14,20 @@ public:
 	Stage1(const Stage1&) = delete;
 
 	/* Getters / Setters -------------------------------------------------------------------------------- */
-	int GetYChipCount() const;
-	int GetXChipCount() const;
-	Map::MapChipType GetMapChipType(int y, int x) const;
-	void GetPlayerFirstChipPos(POINT* pRet) const;
+	UINT16 GetYChipCount() const;
+	UINT16 GetXChipCount() const;
+	Map::MapChipType GetMapChipType(UINT16 y, UINT16 x) const;
+	void GetPlayerFirstChipPos(Point<UINT16>* pRet) const;
 	void GetEnemiesInfo(std::vector<Character::Enemy::EnemyInfo>* pRet) const;
 	int GetEnemyScoutableRadius() const;
-	int GetMaxStoneCount() const;
+	UINT8 GetMaxStoneCount() const;
 
 	/* Operator Overloads ------------------------------------------------------------------------------- */
 	Stage1& operator=(const Stage1&) = delete;
 
 private:
 	/* Constants ---------------------------------------------------------------------------------------- */
-	static const int MAX_STONE_COUNT = 3;
+	static const UINT8 MAX_STONE_COUNT = 3;
 
 };
 

--- a/BestSteal_Replica/StageController.cpp
+++ b/BestSteal_Replica/StageController.cpp
@@ -1,6 +1,4 @@
-﻿#include <vector>
-
-#include "StageController.h"
+﻿#include "StageController.h"
 #include "Stage/Stage1.h"
 #include "Drawing/Drawer.h"
 #include "Map/Map.h"
@@ -31,7 +29,7 @@ void StageController::LoadStage(const Stage::IStage& rStage) {
 	this->pMap->Load(*this->pStage);
 
 	// プレイヤー情報
-	POINT playerChipPos;
+	Point<UINT16> playerChipPos;
 	this->pStage->GetPlayerFirstChipPos(&playerChipPos);
 	POINT playerTopLeftPoint;
 	this->pMap->ConvertMapChipPosToTopLeftPoint(playerChipPos, &playerTopLeftPoint);
@@ -68,7 +66,7 @@ void StageController::Control(const AppCommon::Key& rkey) {
 	int movingPixel = ControlPlayer(&handling);
 
 	// 敵アニメージョン
-	ControlEnemy(movingPixel, handling);
+	ControlEnemy(handling);
 
 	// マップアニメーション
 	ControlMap(movingPixel);
@@ -113,7 +111,7 @@ int StageController::ControlPlayer(Handling* pHandling) {
 
 	if (pHandling->handlingType == Handling::HandlingType::STEAL_OR_OPEN) {
 		// プレイヤーの目の前のマップチップ取得
-		POINT frontMapChipPos;
+		Point<UINT16> frontMapChipPos;
 		this->pMap->ConvertToCharacterFrontMapChipPos(playerRect, this->pPlayer->GetHeadingDirection(), &frontMapChipPos);
 		bool canStartStealing = true;
 		Map::MapChipType mapChipType = this->pMap->GetMapChipType(frontMapChipPos);
@@ -247,7 +245,7 @@ int StageController::ControlPlayer(Handling* pHandling) {
 	return movingPixel;
 }
 
-void StageController::ControlEnemy(int playerMovingPixel, const Handling& rHandling) {
+void StageController::ControlEnemy(const Handling& rHandling) {
 	this->pEnemy->Stay();
 
 	Rectangle<POINT> playerRect;
@@ -265,9 +263,9 @@ void StageController::ControlEnemy(int playerMovingPixel, const Handling& rHandl
 	this->pEnemy->ScoutPlayer(playerCenterPoint, rHandling.isWalking);
 
 	// 突進可能か
-	POINT playerPos;
+	Point<UINT16> playerPos;
 	this->pMap->ConvertToMapChipPos(playerCenterPoint, &playerPos);
-	for (int enemyIdx = 0; enemyIdx < this->pEnemy->GetEnermyCount(); ++enemyIdx) {
+	for (UINT8 enemyIdx = 0; enemyIdx < this->pEnemy->GetEnermyCount(); ++enemyIdx) {
 		if (this->pEnemy->GetState(enemyIdx) == Enemy::State::GOT_STOLEN) {
 			continue;
 		}
@@ -275,10 +273,10 @@ void StageController::ControlEnemy(int playerMovingPixel, const Handling& rHandl
 		// プレイヤーとの距離チェック
 		POINT enemyCenterPoint;
 		pEnemy->CalcCenter(enemyIdx, &enemyCenterPoint);
-		POINT enemyPos;
+		Point<UINT16> enemyPos;
 		this->pMap->ConvertToMapChipPos(enemyCenterPoint, &enemyPos);
 		bool canSeePlayer = false;
-		int distance;
+		int distance = 0;
 		switch (this->pEnemy->GetHeadingDirection(enemyIdx)) {
 			case AppCommon::Direction::TOP:
 				canSeePlayer = (enemyPos.x == playerPos.x && enemyPos.y >= playerPos.y);

--- a/BestSteal_Replica/StageController.h
+++ b/BestSteal_Replica/StageController.h
@@ -25,7 +25,7 @@ public:
 	/**
 	 * キー操作コマンドを示す構造体
 	 * 
-	 * 当構造体はコピー可能
+	 * 当構造体はコピー可能とする。
 	 */
 	struct Handling {
 		enum HandlingType {
@@ -69,7 +69,7 @@ private:
 	/* Functions ---------------------------------------------------------------------------------------- */
 	void ConvertKeyToHandling(const AppCommon::Key& rKey, StageController::Handling* pRet) const;
 	int ControlPlayer(StageController::Handling* pHandling);
-	void ControlEnemy(int playerMovingPixel, const StageController::Handling& rHandling);
+	void ControlEnemy(const StageController::Handling& rHandling);
 	void ControlMap(int playerMovingPixel);
 	void MoveMap(int playerMovingPixel);
 	void RevertStage();

--- a/BestSteal_Replica/stdafx.cpp
+++ b/BestSteal_Replica/stdafx.cpp
@@ -1,0 +1,1 @@
+﻿#include "stdafx.h"

--- a/BestSteal_Replica/stdafx.h
+++ b/BestSteal_Replica/stdafx.h
@@ -1,0 +1,36 @@
+﻿#ifndef STDAFX_H_
+#define STDAFX_H_
+
+#pragma warning( push )
+#pragma warning( disable : 4365 4514 4571 4987 )
+#include <vector>
+#pragma warning( pop )
+
+#pragma warning( push )
+#pragma warning( disable : 4365 4514 4571 4625 4626 5027)
+#include <map>
+#pragma warning( pop )
+
+#pragma warning( push )
+#pragma warning( disable : 4365 4514 )
+#include <algorithm>
+#pragma warning( pop )
+
+#pragma warning( push )
+#pragma warning( disable : 4668 )
+#include <windows.h>
+#pragma warning( pop )
+
+#pragma warning( push )
+#pragma warning( disable : 4514 5029 )
+// new演算子をオーバーロードしているクラスはcrtdbg.hより前にincludeする必要有
+#include <d3dx9math.h>
+#pragma warning( pop )
+
+#if _DEBUG
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
+#endif


### PR DESCRIPTION
- プロジェクトの警告レベルを最大に変更し、警告をエラーとするように設定
- プロジェクトのInclude Path等を絶対パスから相対パスに変更
- 数値型のsigned/ unsignedが合うように型修正
- STL、DirectX等はプリコンパイル済ヘッダに記載し警告をdisableに設定
- ファイルのincludeをファイルからの相対パスでなくソリューションファイルからの相対パスに変更
- `FloatPoint`構造体を廃止し、`POINT`構造体のジェネリック版を作成
- 未使用の引数を削除
- インターフェースクラスのデストラクタをvirtualで定義
- インスタンス変数と同名の引数、ローカル変数は変数名変更
- gitignoreをVS2017で作成したものに変更